### PR TITLE
Refactor: hotkey entrypoints and minor changes to service level

### DIFF
--- a/src/endfield_essence_recognizer/api/routes/scanner.py
+++ b/src/endfield_essence_recognizer/api/routes/scanner.py
@@ -1,13 +1,33 @@
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 
-from endfield_essence_recognizer.core.scanner.engine import ScannerEngine
+from endfield_essence_recognizer.core.interfaces import AutomationEngine
+from endfield_essence_recognizer.core.scanner.engine import (
+    OneTimeRecognitionEngine,
+    ScannerEngine,
+)
 from endfield_essence_recognizer.dependencies import (
+    get_delivery_claimer_engine_dep,
+    get_one_time_recognition_engine_dep,
     get_scanner_engine_dep,
     get_scanner_service,
 )
+from endfield_essence_recognizer.models.scanner import TaskType
 from endfield_essence_recognizer.services.scanner_service import ScannerService
 
 router = APIRouter(prefix="", tags=["scanner"])
+
+
+class ToggleScanningRequest(BaseModel):
+    task_type: TaskType
+
+
+@router.post("/recognize_once")
+async def recognize_once(
+    engine: OneTimeRecognitionEngine = Depends(get_one_time_recognition_engine_dep),
+    scanner_service: ScannerService = Depends(get_scanner_service),
+) -> None:
+    scanner_service.start_scan(scanner_factory=lambda: engine)
 
 
 @router.post("/start_scanning")
@@ -16,3 +36,20 @@ async def start_scanning(
     scanner_service: ScannerService = Depends(get_scanner_service),
 ) -> None:
     scanner_service.toggle_scan(scanner_factory=lambda: scanner)
+
+
+@router.post("/toggle_scanning")
+async def toggle_scanning(
+    request: ToggleScanningRequest,
+    scanner_service: ScannerService = Depends(get_scanner_service),
+    essence_engine: ScannerEngine = Depends(get_scanner_engine_dep),
+    delivery_engine: AutomationEngine = Depends(get_delivery_claimer_engine_dep),
+) -> None:
+    def get_engine() -> AutomationEngine:
+        match request.task_type:
+            case TaskType.ESSENCE:
+                return essence_engine
+            case TaskType.DELIVERY_CLAIM:
+                return delivery_engine
+
+    scanner_service.toggle_scan(scanner_factory=get_engine)

--- a/src/endfield_essence_recognizer/api/routes/scanner.py
+++ b/src/endfield_essence_recognizer/api/routes/scanner.py
@@ -71,5 +71,7 @@ async def toggle_scanning(
                 return essence_engine
             case TaskType.DELIVERY_CLAIM:
                 return delivery_engine
+            case _:
+                raise ValueError(f"Unsupported task type: {request.task_type}")
 
     scanner_service.toggle_scan(scanner_factory=get_engine)

--- a/src/endfield_essence_recognizer/api/routes/scanner.py
+++ b/src/endfield_essence_recognizer/api/routes/scanner.py
@@ -11,6 +11,8 @@ from endfield_essence_recognizer.dependencies import (
     get_one_time_recognition_engine_dep,
     get_scanner_engine_dep,
     get_scanner_service,
+    require_game_or_webview_is_active,
+    require_game_window_exists,
 )
 from endfield_essence_recognizer.models.scanner import TaskType
 from endfield_essence_recognizer.services.scanner_service import ScannerService
@@ -22,7 +24,13 @@ class ToggleScanningRequest(BaseModel):
     task_type: TaskType
 
 
-@router.post("/recognize_once")
+@router.post(
+    "/recognize_once",
+    dependencies=[
+        Depends(require_game_or_webview_is_active),
+        Depends(require_game_window_exists),
+    ],
+)
 async def recognize_once(
     engine: OneTimeRecognitionEngine = Depends(get_one_time_recognition_engine_dep),
     scanner_service: ScannerService = Depends(get_scanner_service),
@@ -30,7 +38,13 @@ async def recognize_once(
     scanner_service.start_scan(scanner_factory=lambda: engine)
 
 
-@router.post("/start_scanning")
+@router.post(
+    "/start_scanning",
+    dependencies=[
+        Depends(require_game_or_webview_is_active),
+        Depends(require_game_window_exists),
+    ],
+)
 async def start_scanning(
     scanner: ScannerEngine = Depends(get_scanner_engine_dep),
     scanner_service: ScannerService = Depends(get_scanner_service),
@@ -38,7 +52,13 @@ async def start_scanning(
     scanner_service.toggle_scan(scanner_factory=lambda: scanner)
 
 
-@router.post("/toggle_scanning")
+@router.post(
+    "/toggle_scanning",
+    dependencies=[
+        Depends(require_game_or_webview_is_active),
+        Depends(require_game_window_exists),
+    ],
+)
 async def toggle_scanning(
     request: ToggleScanningRequest,
     scanner_service: ScannerService = Depends(get_scanner_service),

--- a/src/endfield_essence_recognizer/api/routes/screenshot.py
+++ b/src/endfield_essence_recognizer/api/routes/screenshot.py
@@ -7,6 +7,8 @@ from endfield_essence_recognizer.dependencies import (
     get_resolution_profile_dep,
     get_screenshot_service,
     get_screenshots_dir_dep,
+    require_game_or_webview_is_active,
+    require_game_window_exists,
 )
 from endfield_essence_recognizer.models.screenshot import (
     ImageFormat,
@@ -19,7 +21,10 @@ from endfield_essence_recognizer.utils.log import logger
 router = APIRouter(prefix="", tags=["screenshot"])
 
 
-@router.get("/screenshot")
+@router.get(
+    "/screenshot",
+    dependencies=[Depends(require_game_window_exists)],
+)
 async def get_screenshot(
     width: int = 1920,
     height: int = 1080,
@@ -39,6 +44,10 @@ async def get_screenshot(
 @router.post(
     "/take_and_save_screenshot",
     description="后端截图并保存到本地，返回文件路径和文件名",
+    dependencies=[
+        Depends(require_game_or_webview_is_active),
+        Depends(require_game_window_exists),
+    ],
 )
 async def take_and_save_screenshot(
     request: ScreenshotRequest,

--- a/src/endfield_essence_recognizer/api/routes/system.py
+++ b/src/endfield_essence_recognizer/api/routes/system.py
@@ -2,9 +2,11 @@ import asyncio
 import os
 import platform
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from endfield_essence_recognizer.core.path import get_logs_dir
+from endfield_essence_recognizer.dependencies import get_system_service
+from endfield_essence_recognizer.services.system_service import SystemService
 from endfield_essence_recognizer.utils.log import logger
 from endfield_essence_recognizer.version import __version__
 
@@ -14,6 +16,13 @@ router = APIRouter(prefix="", tags=["system"])
 @router.get("/version")
 async def get_version() -> str | None:
     return __version__
+
+
+@router.post("/exit")
+async def exit_app(
+    system_service: SystemService = Depends(get_system_service),
+) -> None:
+    system_service.exit_application()
 
 
 @router.post("/open_logs_folder")

--- a/src/endfield_essence_recognizer/core/window/manager.py
+++ b/src/endfield_essence_recognizer/core/window/manager.py
@@ -39,6 +39,11 @@ class WindowManager:
         self._window = None
 
     @property
+    def supported_titles(self) -> list[str]:
+        """Get the list of supported window titles."""
+        return self._supported_titles
+
+    @property
     def target_exists(self) -> bool:
         """Check if any supported window is currently open."""
         return self._get_window() is not None

--- a/src/endfield_essence_recognizer/dependencies/__init__.py
+++ b/src/endfield_essence_recognizer/dependencies/__init__.py
@@ -1,7 +1,6 @@
 from .core import (
-    default_delivery_claimer_engine,
-    default_scanner_context,
-    default_scanner_engine,
+    get_delivery_claimer_engine_dep,
+    get_one_time_recognition_engine_dep,
     get_resolution_profile,
     get_resolution_profile_dep,
     get_scanner_context_dep,
@@ -23,6 +22,7 @@ from .services import (
     get_log_service,
     get_scanner_service,
     get_screenshot_service,
+    get_system_service,
     get_webview_window_manager,
 )
 from .settings import (
@@ -32,20 +32,19 @@ from .settings import (
 )
 
 __all__ = [
-    "default_delivery_claimer_engine",
-    "default_scanner_context",
-    "default_scanner_engine",
     "default_user_setting_manager",
     "get_abandon_status_recognizer_dep",
     "get_attribute_level_recognizer_dep",
     "get_attribute_recognizer_dep",
     "get_audio_service",
     "get_config_path_dep",
+    "get_delivery_claimer_engine_dep",
     "get_delivery_job_reward_recognizer_dep",
     "get_delivery_scene_recognizer_dep",
     "get_game_window_manager",
     "get_lock_status_recognizer_dep",
     "get_log_service",
+    "get_one_time_recognition_engine_dep",
     "get_resolution_profile",
     "get_resolution_profile_dep",
     "get_scanner_context_dep",
@@ -53,6 +52,7 @@ __all__ = [
     "get_scanner_service",
     "get_screenshot_service",
     "get_screenshots_dir_dep",
+    "get_system_service",
     "get_ui_scene_recognizer_dep",
     "get_user_setting_manager_at",
     "get_user_setting_manager_dep",

--- a/src/endfield_essence_recognizer/dependencies/__init__.py
+++ b/src/endfield_essence_recognizer/dependencies/__init__.py
@@ -18,17 +18,21 @@ from .recognition import (
 )
 from .services import (
     get_audio_service,
-    get_game_window_manager,
     get_log_service,
     get_scanner_service,
     get_screenshot_service,
     get_system_service,
-    get_webview_window_manager,
 )
 from .settings import (
     default_user_setting_manager,
     get_user_setting_manager_at,
     get_user_setting_manager_dep,
+)
+from .window import (
+    get_game_window_manager,
+    get_webview_window_manager,
+    require_game_or_webview_is_active,
+    require_game_window_exists,
 )
 
 __all__ = [
@@ -57,4 +61,6 @@ __all__ = [
     "get_user_setting_manager_at",
     "get_user_setting_manager_dep",
     "get_webview_window_manager",
+    "require_game_or_webview_is_active",
+    "require_game_window_exists",
 ]

--- a/src/endfield_essence_recognizer/dependencies/core.py
+++ b/src/endfield_essence_recognizer/dependencies/core.py
@@ -17,7 +17,10 @@ from endfield_essence_recognizer.core.recognition import (
 from endfield_essence_recognizer.core.scanner.context import (
     ScannerContext,
 )
-from endfield_essence_recognizer.core.scanner.engine import ScannerEngine
+from endfield_essence_recognizer.core.scanner.engine import (
+    OneTimeRecognitionEngine,
+    ScannerEngine,
+)
 from endfield_essence_recognizer.core.window import WindowManager
 from endfield_essence_recognizer.core.window.adapter import WindowActionsAdapter
 from endfield_essence_recognizer.exceptions import (
@@ -39,7 +42,6 @@ from .services import (
     get_game_window_manager,
 )
 from .settings import (
-    default_user_setting_manager,
     get_user_setting_manager_dep,
 )
 
@@ -71,27 +73,6 @@ def get_resolution_profile() -> ResolutionProfile:
     A non-dependency version of get_resolution_profile_dep.
     """
     return get_resolution_profile_dep(window_manager=get_game_window_manager())
-
-
-def default_scanner_context() -> ScannerContext:
-    """
-    Get the default ScannerContext instance.
-    """
-    from endfield_essence_recognizer.core.recognition import (
-        prepare_abandon_status_recognizer,
-        prepare_attribute_level_recognizer,
-        prepare_attribute_recognizer,
-        prepare_lock_status_recognizer,
-        prepare_ui_scene_recognizer,
-    )
-
-    return ScannerContext(
-        attr_recognizer=prepare_attribute_recognizer(),
-        attr_level_recognizer=prepare_attribute_level_recognizer(),
-        abandon_status_recognizer=prepare_abandon_status_recognizer(),
-        lock_status_recognizer=prepare_lock_status_recognizer(),
-        ui_scene_recognizer=prepare_ui_scene_recognizer(),
-    )
 
 
 def get_scanner_context_dep(
@@ -138,32 +119,37 @@ def get_scanner_engine_dep(
     )
 
 
-def default_scanner_engine() -> ScannerEngine:
+def get_one_time_recognition_engine_dep(
+    ctx: ScannerContext = Depends(get_scanner_context_dep),
+    window_manager: WindowManager = Depends(get_game_window_manager),
+    user_setting_manager: UserSettingManager = Depends(get_user_setting_manager_dep),
+    profile: ResolutionProfile = Depends(get_resolution_profile_dep),
+) -> OneTimeRecognitionEngine:
     """
-    Get the default ScannerEngine instance.
+    Get a OneTimeRecognitionEngine instance.
     """
-    window_manager = get_game_window_manager()
     adapter = WindowActionsAdapter(window_manager)
-    profile = get_resolution_profile()
-    return ScannerEngine(
-        ctx=default_scanner_context(),
+    return OneTimeRecognitionEngine(
+        ctx=ctx,
         image_source=adapter,
         window_actions=adapter,
-        user_setting_manager=default_user_setting_manager(),
+        user_setting_manager=user_setting_manager,
         profile=profile,
     )
 
 
-def default_delivery_claimer_engine() -> DeliveryClaimerEngine:
+def get_delivery_claimer_engine_dep(
+    window_manager: WindowManager = Depends(get_game_window_manager),
+    profile: ResolutionProfile = Depends(get_resolution_profile_dep),
+) -> DeliveryClaimerEngine:
     """
-    Get the default DeliveryClaimerEngine instance.
+    Get a DeliveryClaimerEngine instance.
     """
-    window_manager = get_game_window_manager()
     adapter = WindowActionsAdapter(window_manager)
     return DeliveryClaimerEngine(
         image_source=adapter,
         window_actions=adapter,
-        profile=get_resolution_profile(),
+        profile=profile,
         delivery_scene_recognizer=get_delivery_scene_recognizer_dep(),
         delivery_job_reward_recognizer=get_delivery_job_reward_recognizer_dep(),
         audio_service=get_audio_service(),

--- a/src/endfield_essence_recognizer/dependencies/core.py
+++ b/src/endfield_essence_recognizer/dependencies/core.py
@@ -39,11 +39,11 @@ from .recognition import (
 )
 from .services import (
     get_audio_service,
-    get_game_window_manager,
 )
 from .settings import (
     get_user_setting_manager_dep,
 )
+from .window import get_game_window_manager
 
 
 def get_resolution_profile_dep(

--- a/src/endfield_essence_recognizer/dependencies/core.py
+++ b/src/endfield_essence_recognizer/dependencies/core.py
@@ -11,6 +11,8 @@ from endfield_essence_recognizer.core.recognition import (
     AbandonStatusRecognizer,
     AttributeLevelRecognizer,
     AttributeRecognizer,
+    DeliveryJobRewardRecognizer,
+    DeliverySceneRecognizer,
     LockStatusRecognizer,
     UISceneRecognizer,
 )
@@ -26,6 +28,7 @@ from endfield_essence_recognizer.core.window.adapter import WindowActionsAdapter
 from endfield_essence_recognizer.exceptions import (
     UnsupportedResolutionError,
 )
+from endfield_essence_recognizer.services.audio_service import AudioService
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 
 from .recognition import (
@@ -141,6 +144,13 @@ def get_one_time_recognition_engine_dep(
 def get_delivery_claimer_engine_dep(
     window_manager: WindowManager = Depends(get_game_window_manager),
     profile: ResolutionProfile = Depends(get_resolution_profile_dep),
+    delivery_scene_recognizer: DeliverySceneRecognizer = Depends(
+        get_delivery_scene_recognizer_dep
+    ),
+    delivery_job_reward_recognizer: DeliveryJobRewardRecognizer = Depends(
+        get_delivery_job_reward_recognizer_dep
+    ),
+    audio_service: AudioService = Depends(get_audio_service),
 ) -> DeliveryClaimerEngine:
     """
     Get a DeliveryClaimerEngine instance.
@@ -150,7 +160,7 @@ def get_delivery_claimer_engine_dep(
         image_source=adapter,
         window_actions=adapter,
         profile=profile,
-        delivery_scene_recognizer=get_delivery_scene_recognizer_dep(),
-        delivery_job_reward_recognizer=get_delivery_job_reward_recognizer_dep(),
-        audio_service=get_audio_service(),
+        delivery_scene_recognizer=delivery_scene_recognizer,
+        delivery_job_reward_recognizer=delivery_job_reward_recognizer,
+        audio_service=audio_service,
     )

--- a/src/endfield_essence_recognizer/dependencies/services.py
+++ b/src/endfield_essence_recognizer/dependencies/services.py
@@ -1,10 +1,5 @@
 from functools import lru_cache
 
-from endfield_essence_recognizer.core.webui import get_webview_title
-from endfield_essence_recognizer.core.window import (
-    SUPPORTED_WINDOW_TITLES,
-    WindowManager,
-)
 from endfield_essence_recognizer.services.audio_service import (
     AudioService,
     build_audio_service_profile,
@@ -14,6 +9,8 @@ from endfield_essence_recognizer.services.scanner_service import ScannerService
 from endfield_essence_recognizer.services.screenshot_service import ScreenshotService
 from endfield_essence_recognizer.services.system_service import SystemService
 
+from .window import get_game_window_manager
+
 
 @lru_cache
 def get_audio_service() -> AudioService:
@@ -21,23 +18,6 @@ def get_audio_service() -> AudioService:
     Get the AudioService singleton.
     """
     return AudioService(build_audio_service_profile())
-
-
-@lru_cache
-def get_game_window_manager() -> WindowManager:
-    """
-    Get the singleton WindowManager instance for the game window.
-    """
-    return WindowManager(SUPPORTED_WINDOW_TITLES)
-
-
-@lru_cache
-def get_webview_window_manager() -> WindowManager:
-    """
-    Get the singleton WindowManager instance for the webview window.
-    """
-    # Only contain the single webview title
-    return WindowManager([get_webview_title()])
 
 
 @lru_cache

--- a/src/endfield_essence_recognizer/dependencies/services.py
+++ b/src/endfield_essence_recognizer/dependencies/services.py
@@ -12,6 +12,7 @@ from endfield_essence_recognizer.services.audio_service import (
 from endfield_essence_recognizer.services.log_service import LogService
 from endfield_essence_recognizer.services.scanner_service import ScannerService
 from endfield_essence_recognizer.services.screenshot_service import ScreenshotService
+from endfield_essence_recognizer.services.system_service import SystemService
 
 
 @lru_cache
@@ -41,12 +42,17 @@ def get_webview_window_manager() -> WindowManager:
 
 @lru_cache
 def get_scanner_service() -> ScannerService:
-    return ScannerService()
+    return ScannerService(audio_service=get_audio_service())
 
 
 @lru_cache
 def get_log_service() -> LogService:
     return LogService()
+
+
+@lru_cache
+def get_system_service() -> SystemService:
+    return SystemService(scanner_service=get_scanner_service())
 
 
 @lru_cache

--- a/src/endfield_essence_recognizer/dependencies/window.py
+++ b/src/endfield_essence_recognizer/dependencies/window.py
@@ -1,0 +1,71 @@
+from functools import lru_cache
+
+from fastapi import Depends
+
+from endfield_essence_recognizer.core.webui import get_webview_title
+from endfield_essence_recognizer.core.window import (
+    SUPPORTED_WINDOW_TITLES,
+    WindowManager,
+)
+from endfield_essence_recognizer.exceptions import (
+    WindowNotActiveError,
+    WindowNotFoundError,
+)
+from endfield_essence_recognizer.utils.log import logger
+
+
+@lru_cache
+def get_game_window_manager() -> WindowManager:
+    """
+    Get the singleton WindowManager instance for the game window.
+    """
+    return WindowManager(SUPPORTED_WINDOW_TITLES)
+
+
+@lru_cache
+def get_webview_window_manager() -> WindowManager:
+    """
+    Get the singleton WindowManager instance for the webview window.
+    """
+    # Only contain the single webview title
+    return WindowManager([get_webview_title()])
+
+
+def require_game_window_exists(
+    window_manager: WindowManager = Depends(get_game_window_manager),
+) -> None:
+    """
+    确保终末地游戏窗口存在，否则抛出异常。
+
+    Raises:
+        WindowNotFoundError: 如果游戏窗口不存在。
+    """
+    if not window_manager.target_exists:
+        logger.error("未检测到终末地窗口，无法执行操作。")
+        raise WindowNotFoundError(
+            window_manager._supported_titles, "未检测到终末地窗口，无法执行操作。"
+        )
+
+
+def require_game_or_webview_is_active(
+    window_manager: WindowManager = Depends(get_game_window_manager),
+    webview_window_manager: WindowManager = Depends(get_webview_window_manager),
+) -> None:
+    """
+    确保终末地游戏窗口或 WebView 窗口在前台，否则抛出异常。
+
+    Raises:
+        WindowNotActiveError: 如果游戏窗口或 WebView 窗口不在前台。
+    """
+    if window_manager.target_is_active:
+        logger.debug("终末地窗口在前台，允许操作。")
+        return
+    elif webview_window_manager.target_is_active:
+        logger.debug("WebView 窗口在前台，允许操作。")
+        return
+    else:
+        logger.error("前台窗口不是终末地或 WebView，无法执行操作。")
+        raise WindowNotActiveError(
+            window_manager._supported_titles + webview_window_manager._supported_titles,
+            "前台窗口不是终末地或 WebView，无法执行操作。",
+        )

--- a/src/endfield_essence_recognizer/dependencies/window.py
+++ b/src/endfield_essence_recognizer/dependencies/window.py
@@ -43,7 +43,7 @@ def require_game_window_exists(
     if not window_manager.target_exists:
         logger.error("未检测到终末地窗口，无法执行操作。")
         raise WindowNotFoundError(
-            window_manager._supported_titles, "未检测到终末地窗口，无法执行操作。"
+            window_manager.supported_titles, "未检测到终末地窗口，无法执行操作。"
         )
 
 
@@ -66,6 +66,6 @@ def require_game_or_webview_is_active(
     else:
         logger.error("前台窗口不是终末地或 WebView，无法执行操作。")
         raise WindowNotActiveError(
-            window_manager._supported_titles + webview_window_manager._supported_titles,
+            window_manager.supported_titles + webview_window_manager.supported_titles,
             "前台窗口不是终末地或 WebView，无法执行操作。",
         )

--- a/src/endfield_essence_recognizer/exceptions.py
+++ b/src/endfield_essence_recognizer/exceptions.py
@@ -25,10 +25,27 @@ class WindowNotFoundError(EERError):
     Exception raised when the target window is not found.
     """
 
-    def __init__(self, window_titles: list[str]) -> None:
+    def __init__(self, window_titles: list[str], msg: str = "") -> None:
         self.window_titles = window_titles
         titles_str = ", ".join(window_titles)
-        super().__init__(f"Target window not found. Tried titles: {titles_str}")
+        extra_msg = f" {msg}" if msg else ""
+        super().__init__(
+            f"Target window not found. Tried titles: {titles_str}" + extra_msg
+        )
+
+
+class WindowNotActiveError(EERError):
+    """
+    Exception raised when the target window is not active (in the foreground).
+    """
+
+    def __init__(self, window_titles: list[str], msg: str = "") -> None:
+        self.window_titles = window_titles
+        titles_str = ", ".join(window_titles)
+        extra_msg = f" {msg}" if msg else ""
+        super().__init__(
+            f"Target window not active. Tried titles: {titles_str}" + extra_msg
+        )
 
 
 class UnsupportedResolutionError(EERError):

--- a/src/endfield_essence_recognizer/hotkey_entrypoints.py
+++ b/src/endfield_essence_recognizer/hotkey_entrypoints.py
@@ -99,9 +99,11 @@ def bind_hotkeys(server_config: ServerConfig):
             "=", temp_handle_keyboard_save_screenshot_for_debug, args=("=",)
         )  # 临时热键，用于调试截图功能
     logger.info("全局热键已注册")
+    _ = get_hotkey_client()  # ensure client is initialized
     try:
         yield
     finally:
+        get_hotkey_client().close()
         keyboard.unhook_all()
         logger.info("全局热键已注销")
 

--- a/src/endfield_essence_recognizer/hotkey_entrypoints.py
+++ b/src/endfield_essence_recognizer/hotkey_entrypoints.py
@@ -41,14 +41,16 @@ def hotkey_handler():
 def handle_keyboard_single_recognition(key: str):
     """处理 "[" 键按下事件 - 仅识别不操作"""
     logger.info(f'检测到 "{key}" 键，开始识别基质')
-    get_hotkey_client().post("/recognize_once")
+    get_hotkey_client().post("/recognize_once", key_pressed=key)
 
 
 @hotkey_handler()
 def handle_keyboard_auto_click(key: str):
     """处理 "]" 键按下事件 - 切换自动点击"""
     logger.info(f'检测到 "{key}" 键，切换自动点击状态')
-    get_hotkey_client().post("/toggle_scanning", json={"task_type": TaskType.ESSENCE})
+    get_hotkey_client().post(
+        "/toggle_scanning", json={"task_type": TaskType.ESSENCE}, key_pressed=key
+    )
 
 
 @hotkey_handler()
@@ -56,7 +58,9 @@ def handle_keyboard_delivery_claim(key: str):
     """切换自动抢单状态"""
     logger.info(f'检测到 "{key}" 键，切换自动抢单状态')
     get_hotkey_client().post(
-        "/toggle_scanning", json={"task_type": TaskType.DELIVERY_CLAIM}
+        "/toggle_scanning",
+        json={"task_type": TaskType.DELIVERY_CLAIM},
+        key_pressed=key,
     )
 
 
@@ -64,7 +68,7 @@ def handle_keyboard_delivery_claim(key: str):
 def handle_keyboard_on_exit(key: str):
     """处理 Alt+Delete 按下事件 - 退出程序"""
     logger.info(f'检测到 "{key}"，正在退出程序...')
-    get_hotkey_client().post("/exit")
+    get_hotkey_client().post("/exit", key_pressed=key)
 
 
 @hotkey_handler()
@@ -78,6 +82,7 @@ def temp_handle_keyboard_save_screenshot_for_debug(key: str):
             "title": "Debug",
             "format": "png",
         },
+        key_pressed=key,
     )
 
 

--- a/src/endfield_essence_recognizer/hotkey_entrypoints.py
+++ b/src/endfield_essence_recognizer/hotkey_entrypoints.py
@@ -1,50 +1,20 @@
-import asyncio
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING
 
 import keyboard
 
 from endfield_essence_recognizer.core.config import ServerConfig
 from endfield_essence_recognizer.core.interfaces import HotkeyHandler
-from endfield_essence_recognizer.core.scanner.engine import (
-    recognize_once,
-)
-from endfield_essence_recognizer.dependencies import (
-    default_delivery_claimer_engine,
-    default_scanner_context,
-    default_scanner_engine,
-    default_user_setting_manager,
-    get_audio_service,
-    get_game_window_manager,
-    get_resolution_profile,
-    get_scanner_service,
-    get_screenshot_service,
-    get_screenshots_dir_dep,
-    get_webview_window_manager,
-)
-from endfield_essence_recognizer.models.screenshot import (
-    ScreenshotSaveFormat,
-)
+from endfield_essence_recognizer.models.scanner import TaskType
+from endfield_essence_recognizer.utils.http_client import get_hotkey_client
 from endfield_essence_recognizer.utils.log import (
     logger,
 )
 
-if TYPE_CHECKING:
-    from endfield_essence_recognizer.core.scanner.context import ScannerContext
-    from endfield_essence_recognizer.core.window import WindowManager
 
-
-def hotkey_handler(
-    require_game_exists: bool = True,
-    require_game_or_webview_active: bool = True,
-):
+def hotkey_handler():
     """
-    Hotkey 触发时的装饰器，用于日志记录和窗口状态检查。
-
-    Args:
-        require_game_exists: 是否要求终末地游戏窗口存在。
-        require_game_or_webview_active: 是否要求终末地游戏窗口或 WebView 窗口在前台。
+    Hotkey 触发时的装饰器，用于日志记录。
     """
 
     def decorator(func: HotkeyHandler) -> HotkeyHandler:
@@ -53,16 +23,6 @@ def hotkey_handler(
             logger.debug(f'检测到热键 "{key}" 被按下。')
 
             try:
-                # 如果需要，检查游戏窗口是否存在
-                if require_game_exists:
-                    if not check_game_window_exists():
-                        return
-
-                # 如果需要，检查游戏窗口或 WebView 窗口是否在前台
-                if require_game_or_webview_active:
-                    if not check_game_or_webview_is_active():
-                        return
-
                 # call the actual handler function
                 func(key)
 
@@ -77,152 +37,48 @@ def hotkey_handler(
     return decorator
 
 
-def check_game_window_exists() -> bool:
-    """
-    检查终末地游戏窗口是否存在。
-
-    Returns:
-        bool: 如果游戏窗口存在则返回 True，否则返回 False。
-    """
-    window_manager: WindowManager = get_game_window_manager()
-    if not window_manager.target_exists:
-        logger.debug("未检测到终末地窗口，停止快捷键操作。")
-        return False
-    return True
-
-
-def check_game_or_webview_is_active() -> bool:
-    """
-    检查终末地游戏窗口或 WebView 窗口是否在前台，打印相关日志。
-
-    Returns:
-        bool: 如果游戏窗口或 WebView 窗口在前台则返回 True，否则返回 False。
-    """
-    window_manager: WindowManager = get_game_window_manager()
-    webview_window_manager: WindowManager = get_webview_window_manager()
-
-    if window_manager.target_is_active:
-        logger.debug("终末地窗口在前台，允许快捷键操作。")
-        return True
-    elif webview_window_manager.target_is_active:
-        logger.debug("WebView 窗口在前台，允许快捷键操作。")
-        return True
-    else:
-        logger.debug("前台窗口不是终末地或 WebView，停止快捷键操作。")
-        return False
-
-
-@hotkey_handler(
-    require_game_exists=True,
-    require_game_or_webview_active=True,
-)
+@hotkey_handler()
 def handle_keyboard_single_recognition(key: str):
     """处理 "[" 键按下事件 - 仅识别不操作"""
-    import time
-
-    window_manager: WindowManager = get_game_window_manager()
-    scanner_ctx: ScannerContext = default_scanner_context()
-    resolution_profile = get_resolution_profile()  # may raise exceptions
-    user_setting = default_user_setting_manager().get_user_setting()
-    if not window_manager.target_is_active:
-        logger.debug(
-            f'终末地窗口不在前台，尝试切换到前台以进行识别基质操作 "{key}" 键。'
-        )
-        if window_manager.activate():
-            time.sleep(0.3)
-        if window_manager.show():
-            # make sure the window is visible
-            time.sleep(0.3)
-
     logger.info(f'检测到 "{key}" 键，开始识别基质')
-    recognize_once(
-        window_manager,
-        scanner_ctx,
-        user_setting,
-        resolution_profile,
-    )
+    get_hotkey_client().post("/recognize_once")
 
 
-def handle_keyboard_toggle_scan():
-    """切换基质扫描状态"""
-    scanner_service = get_scanner_service()
-    audio_service = get_audio_service()
-
-    if not scanner_service.is_running():
-        logger.info("开始扫描基质")
-        scanner = default_scanner_engine()
-        scanner_service.start_scan(scanner_factory=lambda: scanner)
-        audio_service.play_enable()
-    else:
-        logger.info("停止扫描基质")
-        audio_service.play_disable()
-        scanner_service.stop_scan()
-
-
-@hotkey_handler(
-    require_game_exists=True,
-    require_game_or_webview_active=True,
-)
+@hotkey_handler()
 def handle_keyboard_auto_click(key: str):
     """处理 "]" 键按下事件 - 切换自动点击"""
     logger.info(f'检测到 "{key}" 键，切换自动点击状态')
-    handle_keyboard_toggle_scan()
+    get_hotkey_client().post("/toggle_scanning", json={"task_type": TaskType.ESSENCE})
 
 
-@hotkey_handler(
-    require_game_exists=True,
-    require_game_or_webview_active=True,
-)
+@hotkey_handler()
 def handle_keyboard_delivery_claim(key: str):
     """切换自动抢单状态"""
-    scanner_service = get_scanner_service()
-    audio_service = get_audio_service()
-
-    if not scanner_service.is_running():
-        logger.info(f'检测到 "{key}" 键，开始自动抢单')
-        engine = default_delivery_claimer_engine()
-        scanner_service.start_scan(scanner_factory=lambda: engine)
-        audio_service.play_enable()
-    else:
-        logger.info(f'检测到 "{key}" 键，停止自动抢单')
-        audio_service.play_disable()
-        scanner_service.stop_scan()
+    logger.info(f'检测到 "{key}" 键，切换自动抢单状态')
+    get_hotkey_client().post(
+        "/toggle_scanning", json={"task_type": TaskType.DELIVERY_CLAIM}
+    )
 
 
-@hotkey_handler(require_game_exists=False, require_game_or_webview_active=False)
+@hotkey_handler()
 def handle_keyboard_on_exit(key: str):
     """处理 Alt+Delete 按下事件 - 退出程序"""
     logger.info(f'检测到 "{key}"，正在退出程序...')
-
-    # 停止扫描器
-    scanner_service = get_scanner_service()
-    if scanner_service.is_running():
-        scanner_service.stop_scan()
-
-    # 关闭 webview 窗口，剩下的清理工作交给 main 函数
-    from endfield_essence_recognizer.webui import window
-
-    window.destroy()
+    get_hotkey_client().post("/exit")
 
 
-@hotkey_handler(
-    require_game_exists=True,
-    require_game_or_webview_active=True,
-)
+@hotkey_handler()
 def temp_handle_keyboard_save_screenshot_for_debug(key: str):
-    screenshot_service = get_screenshot_service()
-    full_path, file_name = asyncio.run(
-        screenshot_service.capture_and_save(
-            screenshot_dir=get_screenshots_dir_dep(),
-            resolution_profile=get_resolution_profile(),
-            should_focus=True,
-            post_process=True,
-            title="Debug",
-            fmt=ScreenshotSaveFormat.PNG,
-        )
+    logger.info(f'检测到 "{key}" 键，正在保存调试截图...')
+    get_hotkey_client().post(
+        "/take_and_save_screenshot",
+        json={
+            "should_focus": True,
+            "post_process": True,
+            "title": "Debug",
+            "format": "png",
+        },
     )
-    logger.info(f"截图已保存到 {full_path}")
-    logger.info(f"截图文件名: {file_name}")
 
 
 @contextmanager

--- a/src/endfield_essence_recognizer/models/scanner.py
+++ b/src/endfield_essence_recognizer/models/scanner.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+
+class TaskType(StrEnum):
+    """表示希望 ScannerService 执行的任务类型"""
+
+    ESSENCE = "essence"
+    """扫描基质"""
+    DELIVERY_CLAIM = "delivery_claim"
+    """自动抢单"""

--- a/src/endfield_essence_recognizer/server.py
+++ b/src/endfield_essence_recognizer/server.py
@@ -36,8 +36,8 @@ async def window_not_found_exception_handler(
     _request: Request, exc: WindowNotFoundError
 ):
     """
-    WindowNotFoundError are raised when the target window is not found.
-    Generally this means the game window is not open，and therefore we
+    WindowNotFoundError is raised when the target window is not found.
+    Generally this means the game window is not open, and therefore we
     cannot perform the requested operation.
 
     We return a 404 status code here to indicate that the target window
@@ -54,7 +54,7 @@ async def window_not_active_exception_handler(
     _request: Request, exc: WindowNotActiveError
 ):
     """
-    WindowNotActiveError are raised when the the active window is
+    WindowNotActiveError is raised when the the active window is
     not what we expect. Normally this means the user triggers an action
     when either the game window or the webview is not in the foreground.
 

--- a/src/endfield_essence_recognizer/server.py
+++ b/src/endfield_essence_recognizer/server.py
@@ -13,6 +13,7 @@ from endfield_essence_recognizer.api.router import api_router, ws_router
 from endfield_essence_recognizer.core.config import ServerConfig, get_server_config
 from endfield_essence_recognizer.exceptions import (
     UnsupportedResolutionError,
+    WindowNotActiveError,
     WindowNotFoundError,
 )
 from endfield_essence_recognizer.lifespan import lifespan
@@ -34,6 +35,32 @@ app.add_middleware(
 async def window_not_found_exception_handler(
     _request: Request, exc: WindowNotFoundError
 ):
+    """
+    WindowNotFoundError are raised when the target window is not found.
+    Generally this means the game window is not open，and therefore we
+    cannot perform the requested operation.
+
+    We return a 404 status code here to indicate that the target window
+    is "not found".
+    """
+    return JSONResponse(
+        status_code=404,
+        content={"detail": str(exc)},
+    )
+
+
+@app.exception_handler(WindowNotActiveError)
+async def window_not_active_exception_handler(
+    _request: Request, exc: WindowNotActiveError
+):
+    """
+    WindowNotActiveError are raised when the the active window is
+    not what we expect. Normally this means the user triggers an action
+    when either the game window or the webview is not in the foreground.
+
+    We return a 404 status code here to indicate that the target window
+    is "not found" in the foreground.
+    """
     return JSONResponse(
         status_code=404,
         content={"detail": str(exc)},
@@ -44,6 +71,13 @@ async def window_not_found_exception_handler(
 async def unsupported_resolution_exception_handler(
     _request: Request, exc: UnsupportedResolutionError
 ):
+    """
+    UnsupportedResolutionError are raised when the resolution of the game
+    window is not supported by the application.
+
+    We return a 400 status code here to indicate that the client made
+    a bad request.
+    """
     return JSONResponse(
         status_code=400,
         content={"detail": str(exc)},

--- a/src/endfield_essence_recognizer/services/system_service.py
+++ b/src/endfield_essence_recognizer/services/system_service.py
@@ -1,0 +1,24 @@
+from endfield_essence_recognizer.services.scanner_service import ScannerService
+from endfield_essence_recognizer.utils.log import logger
+
+
+class SystemService:
+    """Service for managing application-level operations."""
+
+    def __init__(self, scanner_service: ScannerService):
+        self._scanner_service = scanner_service
+
+    def exit_application(self):
+        """Gracefully shut down the application."""
+        logger.info("正在执行程序退出流程...")
+
+        # 停止所有正在运行的扫描任务
+        if self._scanner_service.is_running():
+            logger.debug("正在停止活动扫描任务...")
+            self._scanner_service.stop_scan()
+
+        # 关闭 Webview 窗口
+        from endfield_essence_recognizer.webui import window
+
+        logger.debug("正在销毁 Webview 窗口...")
+        window.destroy()

--- a/src/endfield_essence_recognizer/utils/http_client.py
+++ b/src/endfield_essence_recognizer/utils/http_client.py
@@ -1,0 +1,34 @@
+import httpx
+
+from endfield_essence_recognizer.core.config import get_server_config
+from endfield_essence_recognizer.utils.log import logger
+
+
+class HotkeyClient:
+    """A minimal HTTP client for sending commands to the local FastAPI server."""
+
+    def __init__(self):
+        config = get_server_config()
+        self.base_url = f"http://{config.api_host}:{config.api_port}/api"
+        self.client = httpx.Client(timeout=5.0)
+
+    def post(self, endpoint: str, json: dict | None = None):
+        """Send a POST request to the backend."""
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        try:
+            response = self.client.post(url, json=json)
+            response.raise_for_status()
+            logger.debug(f"成功发送请求到 {url}")
+        except Exception as e:
+            logger.error(f"发送请求到 {url} 失败: {e}")
+
+
+_client = None
+
+
+def get_hotkey_client() -> HotkeyClient:
+    """Get the global HotkeyClient instance."""
+    global _client
+    if _client is None:
+        _client = HotkeyClient()
+    return _client

--- a/src/endfield_essence_recognizer/utils/http_client.py
+++ b/src/endfield_essence_recognizer/utils/http_client.py
@@ -12,15 +12,27 @@ class HotkeyClient:
         self.base_url = f"http://{config.api_host}:{config.api_port}/api"
         self.client = httpx.Client(timeout=5.0)
 
-    def post(self, endpoint: str, json: dict | None = None):
+    def post(
+        self, endpoint: str, json: dict | None = None, key_pressed: str = ""
+    ) -> None:
         """Send a POST request to the backend."""
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        caller = f"Hotkey '{key_pressed}'" if key_pressed else "HotkeyClient"
         try:
             response = self.client.post(url, json=json)
             response.raise_for_status()
             logger.debug(f"成功发送请求到 {url}")
+        except httpx.HTTPStatusError as e:
+            # this means the server returned an error response
+            # we expect that server has logged the error details
+            # we only log as the hotkey client
+            response_body = e.response.text
+            status_code = e.response.status_code
+            logger.warning(
+                f"{caller} 发送请求到 {url} 后发生错误：{status_code}, 响应内容: {response_body}"
+            )
         except Exception as e:
-            logger.error(f"发送请求到 {url} 失败: {e}")
+            logger.warning(f"{caller} 发送请求到 {url} 失败: {e}")
 
 
 _client = None

--- a/src/endfield_essence_recognizer/utils/http_client.py
+++ b/src/endfield_essence_recognizer/utils/http_client.py
@@ -34,6 +34,10 @@ class HotkeyClient:
         except Exception as e:
             logger.warning(f"{caller} 发送请求到 {url} 失败: {e}")
 
+    def close(self):
+        """Close the HTTP client."""
+        self.client.close()
+
 
 _client = None
 

--- a/tests/integration/test_scanner_api.py
+++ b/tests/integration/test_scanner_api.py
@@ -31,6 +31,7 @@ def client(mock_scanner_service):
     """FastAPI TestClient with overridden dependencies."""
     app.dependency_overrides[get_scanner_service] = lambda: mock_scanner_service
     # Mock engines to avoid real initialization
+    # use explicit lambdas to avoid fastapi caching MagicMock instance
     app.dependency_overrides[get_scanner_engine_dep] = lambda: MagicMock()
     app.dependency_overrides[get_one_time_recognition_engine_dep] = lambda: MagicMock()
     app.dependency_overrides[get_delivery_claimer_engine_dep] = lambda: MagicMock()

--- a/tests/integration/test_scanner_api.py
+++ b/tests/integration/test_scanner_api.py
@@ -8,6 +8,8 @@ from endfield_essence_recognizer.dependencies import (
     get_one_time_recognition_engine_dep,
     get_scanner_engine_dep,
     get_scanner_service,
+    require_game_or_webview_is_active,
+    require_game_window_exists,
 )
 from endfield_essence_recognizer.server import app
 from endfield_essence_recognizer.services.scanner_service import ScannerService
@@ -32,6 +34,10 @@ def client(mock_scanner_service):
     app.dependency_overrides[get_scanner_engine_dep] = lambda: MagicMock()
     app.dependency_overrides[get_one_time_recognition_engine_dep] = lambda: MagicMock()
     app.dependency_overrides[get_delivery_claimer_engine_dep] = lambda: MagicMock()
+
+    # Bypass window checks
+    app.dependency_overrides[require_game_window_exists] = lambda: None
+    app.dependency_overrides[require_game_or_webview_is_active] = lambda: None
 
     with TestClient(app) as client:
         yield client

--- a/tests/integration/test_scanner_api.py
+++ b/tests/integration/test_scanner_api.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from endfield_essence_recognizer.dependencies import (
+    get_delivery_claimer_engine_dep,
+    get_one_time_recognition_engine_dep,
+    get_scanner_engine_dep,
+    get_scanner_service,
+)
+from endfield_essence_recognizer.server import app
+from endfield_essence_recognizer.services.scanner_service import ScannerService
+
+
+@pytest.fixture
+def mock_scanner_service():
+    """Mock ScannerService to avoid starting real threads."""
+    service = ScannerService()
+    service.start_scan = MagicMock()
+    service.stop_scan = MagicMock()
+    service.toggle_scan = MagicMock()
+    service.is_running = MagicMock(return_value=False)
+    return service
+
+
+@pytest.fixture
+def client(mock_scanner_service):
+    """FastAPI TestClient with overridden dependencies."""
+    app.dependency_overrides[get_scanner_service] = lambda: mock_scanner_service
+    # Mock engines to avoid real initialization
+    app.dependency_overrides[get_scanner_engine_dep] = lambda: MagicMock()
+    app.dependency_overrides[get_one_time_recognition_engine_dep] = lambda: MagicMock()
+    app.dependency_overrides[get_delivery_claimer_engine_dep] = lambda: MagicMock()
+
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_recognize_once_endpoint(client, mock_scanner_service):
+    """Test POST /api/recognize_once."""
+    response = client.post("/api/recognize_once")
+    assert response.status_code == 200
+    assert mock_scanner_service.start_scan.called
+
+
+def test_start_scanning_endpoint(client, mock_scanner_service):
+    """Test POST /api/start_scanning."""
+    response = client.post("/api/start_scanning")
+    # This is the original endpoint used by the frontend
+    assert response.status_code == 200
+    assert mock_scanner_service.toggle_scan.called
+
+
+def test_toggle_scanning_essence(client, mock_scanner_service):
+    """Test POST /api/toggle_scanning for essence."""
+    response = client.post("/api/toggle_scanning", json={"task_type": "essence"})
+    assert response.status_code == 200
+    assert mock_scanner_service.toggle_scan.called
+
+
+def test_toggle_scanning_delivery(client, mock_scanner_service):
+    """Test POST /api/toggle_scanning for delivery_claim."""
+    response = client.post("/api/toggle_scanning", json={"task_type": "delivery_claim"})
+    assert response.status_code == 200
+    assert mock_scanner_service.toggle_scan.called
+
+
+def test_toggle_scanning_invalid(client):
+    """Test POST /api/toggle_scanning with invalid task type."""
+    response = client.post("/api/toggle_scanning", json={"task_type": "invalid"})
+    assert response.status_code == 422

--- a/tests/integration/test_screenshot_api.py
+++ b/tests/integration/test_screenshot_api.py
@@ -8,6 +8,8 @@ from endfield_essence_recognizer.dependencies import (
     get_resolution_profile_dep,
     get_screenshot_service,
     get_screenshots_dir_dep,
+    require_game_or_webview_is_active,
+    require_game_window_exists,
 )
 from endfield_essence_recognizer.server import app
 
@@ -28,6 +30,10 @@ def client(mock_screenshot_service, tmp_path):
     app.dependency_overrides[get_screenshots_dir_dep] = lambda: tmp_path
     # Override Resolution Profile to avoid window lookup in tests
     app.dependency_overrides[get_resolution_profile_dep] = lambda: Resolution1080p()
+
+    # Bypass window checks
+    app.dependency_overrides[require_game_window_exists] = lambda: None
+    app.dependency_overrides[require_game_or_webview_is_active] = lambda: None
 
     with TestClient(app) as client:
         yield client

--- a/tests/integration/test_system_api.py
+++ b/tests/integration/test_system_api.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from endfield_essence_recognizer.dependencies import get_system_service
+from endfield_essence_recognizer.server import app
+from endfield_essence_recognizer.services.system_service import SystemService
+
+
+@pytest.fixture
+def mock_system_service():
+    service = MagicMock(spec=SystemService)
+    return service
+
+
+@pytest.fixture
+def client(mock_system_service):
+    app.dependency_overrides[get_system_service] = lambda: mock_system_service
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_exit_endpoint(client, mock_system_service):
+    """Test POST /api/exit."""
+    response = client.post("/api/exit")
+    assert response.status_code == 200
+    assert mock_system_service.exit_application.called


### PR DESCRIPTION
Closes #109

- 快捷键只负责发http请求到对应api。
- 老的快捷键逻辑移动到api端点内。
- ScannerService接收AudioService并控制音效播放。
- “单次扫描”封装成AutomationEngine并交给ScannerService控制。
- hotkey_handler不再负责检查游戏窗口是否存在、游戏窗口和WebView是否在最前。
  - 转由api端点负责处理
- 优化日志信息
