### PR TITLE
feat: 武器基质数量统计, 前端轮询更新状态

### DIFF
--- a/frontend/src/composables/useScanningStatus.ts
+++ b/frontend/src/composables/useScanningStatus.ts
@@ -1,0 +1,76 @@
+import { onUnmounted, ref } from 'vue'
+
+const isScanning = ref(false)
+let statusCheckInterval: number | null = null
+let refCount = 0
+let pollingEnabled = true
+
+async function checkScanningStatus() {
+  try {
+    const response = await fetch('/api/scanning_status')
+    const status = await response.json()
+    isScanning.value = status.is_running
+  } catch (error) {
+    console.error('Failed to check scanning status:', error)
+  }
+}
+
+function startStatusPolling() {
+  refCount++
+
+  if (statusCheckInterval !== null || !pollingEnabled) {
+    return
+  }
+
+  checkScanningStatus()
+  statusCheckInterval = window.setInterval(checkScanningStatus, 1000)
+}
+
+function stopStatusPolling() {
+  refCount--
+
+  if (refCount <= 0) {
+    refCount = 0
+    if (statusCheckInterval !== null) {
+      window.clearInterval(statusCheckInterval)
+      statusCheckInterval = null
+    }
+  }
+}
+
+export function useScanningStatus(enabled?: boolean) {
+  // 从 localStorage 读取 默认禁用
+  const storedEnabled = localStorage.getItem('scanningStatusPollingEnabled')
+  pollingEnabled = enabled ?? (storedEnabled === 'true')
+
+  if (pollingEnabled) {
+    startStatusPolling()
+  }
+
+  onUnmounted(() => {
+    stopStatusPolling()
+  })
+
+  return {
+    isScanning,
+    pollingEnabled,
+  }
+}
+
+/**
+ * 设置是否启用状态轮询
+ */
+export function setScanningStatusPolling(enabled: boolean) {
+  pollingEnabled = enabled
+  localStorage.setItem('scanningStatusPollingEnabled', String(enabled))
+
+  if (enabled && refCount > 0 && statusCheckInterval === null) {
+    // 启用
+    checkScanningStatus()
+    statusCheckInterval = window.setInterval(checkScanningStatus, 1000)
+  } else if (!enabled && statusCheckInterval !== null) {
+    // 禁用
+    window.clearInterval(statusCheckInterval)
+    statusCheckInterval = null
+  }
+}

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -3,7 +3,9 @@
     <div>
       <h1 v-if="false">日志</h1>
       <div class="d-flex flex-row flex-wrap ga-3">
-        <v-btn color="primary" @click="startScanning">开始扫描基质</v-btn>
+        <v-btn :color="isScanning ? 'warning' : 'primary'" @click="toggleScanning">
+          {{ isScanning ? '停止扫描基质' : '开始扫描基质' }}
+        </v-btn>
         <v-spacer />
         <v-btn color="error" @click="clearLogs">清空日志</v-btn>
         <v-btn :color="autoScroll ? 'success' : 'warning'" @click="toggleAutoScroll">
@@ -29,14 +31,16 @@
 <script lang="ts" setup>
 import { nextTick, onMounted, ref, watch } from 'vue'
 import { clearLogs, logs } from '@/composables/useLogs'
+import { useScanningStatus } from '@/composables/useScanningStatus'
 
 const autoScroll = ref(true)
+const { isScanning } = useScanningStatus()
 
 function toggleAutoScroll() {
   autoScroll.value = !autoScroll.value
 }
 
-function startScanning() {
+function toggleScanning() {
   fetch('/api/start_scanning', { method: 'POST' })
 }
 

--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -525,8 +525,8 @@ async function postConfig() {
 async function fetchWeaponEssenceCounts() {
   try {
     const response = await fetch(`/api/weapon_essence_counts`)
-    const counts = await response.json()
-    weaponEssenceCounts.value = counts
+    const result = await response.json()
+    weaponEssenceCounts.value = result.counts
   } catch (error) {
     console.error('Failed to fetch weapon essence counts:', error)
   }

--- a/src/endfield_essence_recognizer/api/routes/scanner.py
+++ b/src/endfield_essence_recognizer/api/routes/scanner.py
@@ -75,3 +75,22 @@ async def toggle_scanning(
                 raise ValueError(f"Unsupported task type: {request.task_type}")
 
     scanner_service.toggle_scan(scanner_factory=get_engine)
+
+
+@router.get("/weapon_essence_counts")
+async def get_weapon_essence_counts(
+    scanner_service: ScannerService = Depends(get_scanner_service),
+) -> dict[str, int]:
+    """
+    获取最后一次扫描的武器基质数量统计
+
+    -> dict[武器ID, 数量]
+    """
+    return scanner_service.get_weapon_essence_counts()
+
+
+@router.get("/scanning_status")
+async def get_scanning_status(
+    scanner_service: ScannerService = Depends(get_scanner_service),
+) -> dict[str, bool]:
+    return {"is_running": scanner_service.is_running()}

--- a/src/endfield_essence_recognizer/api/routes/scanner.py
+++ b/src/endfield_essence_recognizer/api/routes/scanner.py
@@ -14,7 +14,7 @@ from endfield_essence_recognizer.dependencies import (
     require_game_or_webview_is_active,
     require_game_window_exists,
 )
-from endfield_essence_recognizer.schemas.scanner import TaskType
+from endfield_essence_recognizer.schemas.scanner import TaskType, WeaponEssenceCounts
 from endfield_essence_recognizer.services.scanner_service import ScannerService
 
 router = APIRouter(prefix="", tags=["scanner"])
@@ -80,13 +80,13 @@ async def toggle_scanning(
 @router.get("/weapon_essence_counts")
 async def get_weapon_essence_counts(
     scanner_service: ScannerService = Depends(get_scanner_service),
-) -> dict[str, int]:
+) -> WeaponEssenceCounts:
     """
-    获取最后一次扫描的武器基质数量统计
+    获取扫描的武器基质数量统计
 
-    -> dict[武器ID, 数量]
+    -> WeaponEssenceCounts(counts: dict[武器ID, 数量])
     """
-    return scanner_service.get_weapon_essence_counts()
+    return WeaponEssenceCounts(counts=scanner_service.get_weapon_essence_counts())
 
 
 @router.get("/scanning_status")

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -22,6 +22,7 @@ from endfield_essence_recognizer.core.scanner.models import (
     EssenceQuality,
 )
 from endfield_essence_recognizer.core.window.adapter import InMemoryImageSource
+from endfield_essence_recognizer.game_data.models.v2 import WeaponId
 from endfield_essence_recognizer.schemas.user_setting import UserSetting
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 from endfield_essence_recognizer.utils.log import logger
@@ -239,7 +240,9 @@ class ScannerEngine:
         self._window_actions = window_actions
         self._user_setting_manager: UserSettingManager = user_setting_manager
         self._profile: ResolutionProfile = profile
-        self._weapon_essence_counts: dict[str, int] = {}
+
+        # 以下两个字段是 ScannerEngine 维护的运行时状态
+        self._weapon_essence_counts: dict[WeaponId, int] = {}
         self._total_essence_count: int = 0
 
         from endfield_essence_recognizer.utils.log import str_properties_and_attrs
@@ -257,7 +260,7 @@ class ScannerEngine:
         self._execute_grid_scan(stop_event)
         logger.debug("ScannerEngine finished execution.")
 
-    def get_weapon_essence_counts(self) -> dict[str, int]:
+    def get_weapon_essence_counts(self) -> dict[WeaponId, int]:
         """
         Get the weapon essence counts from the last scan.
 
@@ -340,8 +343,11 @@ class ScannerEngine:
                 self._total_essence_count += 1
 
             # 为匹配的非垃圾武器的基质数量自增
-            if evaluation.matched_non_trash_weapons:
-                for weapon_id in evaluation.matched_non_trash_weapons:
+            if (
+                evaluation.matched_weapons
+                and not evaluation.matched_weapons_all_blocked
+            ):
+                for weapon_id in evaluation.matched_weapons:
                     self._weapon_essence_counts[weapon_id] = (
                         self._weapon_essence_counts.get(weapon_id, 0) + 1
                     )
@@ -378,7 +384,7 @@ class ScannerEngine:
         logger.info(f"共扫描了 {self._total_essence_count} 个基质。")
         if self._weapon_essence_counts:
             # 按 稀有度降序 武器ID 排序
-            def sort_key(item: tuple[str, int]) -> tuple[int, str]:
+            def sort_key(item: tuple[WeaponId, int]) -> tuple[int, WeaponId]:
                 weapon_id, _ = item
                 weapon = self.ctx.static_game_data.get_weapon(weapon_id)
                 # 负数使稀有度按降序排序

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -135,6 +135,8 @@ def evaluate_essence(
             quality=EssenceQuality.TREASURE,
             log_message=f"这个基质是<green><bold><underline>宝藏</></></>，它完美契合武器{weapons_description_str}{high_level_info}。",
             matched_weapons=non_trash_weapon_ids,
+            # 赋值相同但是意义不同
+            matched_non_trash_weapons=non_trash_weapon_ids,
             is_high_level=is_high_level_treasure,
         )
     else:

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -135,8 +135,7 @@ def evaluate_essence(
             quality=EssenceQuality.TREASURE,
             log_message=f"这个基质是<green><bold><underline>宝藏</></></>，它完美契合武器{weapons_description_str}{high_level_info}。",
             matched_weapons=non_trash_weapon_ids,
-            # 赋值相同但是意义不同
-            matched_non_trash_weapons=non_trash_weapon_ids,
+            matched_weapons_all_blocked=False,
             is_high_level=is_high_level_treasure,
         )
     else:
@@ -153,6 +152,7 @@ def evaluate_essence(
                 quality=EssenceQuality.TREASURE,
                 log_message=f"这个基质是<green><bold><underline>宝藏</></></>，因为它有高等级属性词条{high_level_info}。<yellow>即使它匹配的所有武器{weapons_description_str}均已被用户手动拦截。</>",
                 matched_weapons=matched_weapon_ids,
+                matched_weapons_all_blocked=True,
                 is_high_level=True,
             )
         else:
@@ -160,5 +160,6 @@ def evaluate_essence(
                 quality=EssenceQuality.TRASH,
                 log_message=f"这个基质虽然匹配武器{weapons_description_str}，但匹配的所有武器均已被用户手动拦截，因此这个基质是<red><bold><underline>养成材料</></></>。",
                 matched_weapons=matched_weapon_ids,
+                matched_weapons_all_blocked=True,
                 is_high_level=False,
             )

--- a/src/endfield_essence_recognizer/core/scanner/models.py
+++ b/src/endfield_essence_recognizer/core/scanner/models.py
@@ -58,5 +58,11 @@ class EvaluationResult:
     matched_weapons: set[WeaponId] = field(default_factory=set)
     """Set of weapon IDs that this essence is suitable for."""
 
+    matched_non_trash_weapons: set[WeaponId] = field(default_factory=set)
+    """
+    Set of non-trash weapon IDs that this essence matches (excluding user-blocked weapons).
+    Used for incrementing weapon essence counts.
+    """
+
     is_high_level: bool = False
     """Whether any attribute on the essence exceeded a high-level threshold."""

--- a/src/endfield_essence_recognizer/core/scanner/models.py
+++ b/src/endfield_essence_recognizer/core/scanner/models.py
@@ -58,11 +58,8 @@ class EvaluationResult:
     matched_weapons: set[WeaponId] = field(default_factory=set)
     """Set of weapon IDs that this essence is suitable for."""
 
-    matched_non_trash_weapons: set[WeaponId] = field(default_factory=set)
-    """
-    Set of non-trash weapon IDs that this essence matches (excluding user-blocked weapons).
-    Used for incrementing weapon essence counts.
-    """
+    matched_weapons_all_blocked: bool = False
+    """True if all weapons in matched_weapons are blocked by the user (trash_weapon_ids)."""
 
     is_high_level: bool = False
     """Whether any attribute on the essence exceeded a high-level threshold."""

--- a/src/endfield_essence_recognizer/schemas/scanner.py
+++ b/src/endfield_essence_recognizer/schemas/scanner.py
@@ -1,5 +1,9 @@
 from enum import StrEnum
 
+from pydantic import BaseModel
+
+from endfield_essence_recognizer.game_data.models.v2 import WeaponId
+
 
 class TaskType(StrEnum):
     """表示希望 ScannerService 执行的任务类型"""
@@ -8,3 +12,10 @@ class TaskType(StrEnum):
     """扫描基质"""
     DELIVERY_CLAIM = "delivery_claim"
     """自动抢单"""
+
+
+class WeaponEssenceCounts(BaseModel):
+    """武器基质数量统计"""
+
+    counts: dict[WeaponId, int]
+    """各武器 ID 对应的匹配基质数量"""

--- a/src/endfield_essence_recognizer/services/scanner_service.py
+++ b/src/endfield_essence_recognizer/services/scanner_service.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from endfield_essence_recognizer.core.interfaces import AutomationEngine
+    from endfield_essence_recognizer.game_data.models.v2 import WeaponId
     from endfield_essence_recognizer.services.audio_service import AudioService
 
 
@@ -35,8 +36,8 @@ class ScannerService:
         self._stop_event = threading.Event()  # Event to signal the thread to stop
         self._lock = threading.RLock()  # Reentrant lock for nested locking
         self._audio_service = audio_service
-        self._current_scanner: AutomationEngine | None = None
-        self._last_weapon_essence_counts: dict[str, int] = {}
+        self._current_engine: AutomationEngine | None = None
+        self._last_weapon_essence_counts: dict[WeaponId, int] = {}
 
     def start_scan(self, scanner_factory: Callable[[], AutomationEngine]) -> None:
         """
@@ -60,7 +61,7 @@ class ScannerService:
             logger.debug("正在启动扫描服务...")
             self._stop_event.clear()
             scanner = scanner_factory()
-            self._current_scanner = scanner
+            self._current_engine = scanner
 
             self._thread = threading.Thread(
                 target=scanner.execute,
@@ -94,17 +95,17 @@ class ScannerService:
                 self._thread = None
 
             # 保存最后一次扫描的统计数据
-            if self._current_scanner is not None:
+            if self._current_engine is not None:
                 from endfield_essence_recognizer.core.scanner.engine import (
                     ScannerEngine,
                 )
 
-                if isinstance(self._current_scanner, ScannerEngine):
+                if isinstance(self._current_engine, ScannerEngine):
                     self._last_weapon_essence_counts = (
-                        self._current_scanner.get_weapon_essence_counts()
+                        self._current_engine.get_weapon_essence_counts()
                     )
 
-            self._current_scanner = None
+            self._current_engine = None
 
             if self._audio_service:
                 self._audio_service.play_disable()
@@ -119,32 +120,35 @@ class ScannerService:
         with self._lock:
             return self._thread is not None and self._thread.is_alive()
 
-    def get_current_scanner(self) -> AutomationEngine | None:
+    def get_current_engine(self) -> AutomationEngine | None:
         """
-        Get the current scanner instance.
+        Get the current engine instance.
 
         Returns:
-            The current scanner instance, or None if no scanner is running.
+            The current engine instance, or None if no engine is running.
         """
         with self._lock:
-            return self._current_scanner
+            return self._current_engine
 
-    def get_weapon_essence_counts(self) -> dict[str, int]:
+    def get_weapon_essence_counts(self) -> dict[WeaponId, int]:
         """
-        Get the weapon essence counts from the last scan.
+        Get the weapon essence counts.
+
+        Returns the real-time data from the currently running scan if a ScannerEngine
+        task is active, or the data from the last finished scan otherwise.
 
         Returns:
             A dictionary mapping weapon IDs to essence counts.
         """
         with self._lock:
             # 如果当前有正在运行的 ScannerEngine，返回实时数据
-            if self._current_scanner is not None:
+            if self._current_engine is not None:
                 from endfield_essence_recognizer.core.scanner.engine import (
                     ScannerEngine,
                 )
 
-                if isinstance(self._current_scanner, ScannerEngine):
-                    return self._current_scanner.get_weapon_essence_counts()
+                if isinstance(self._current_engine, ScannerEngine):
+                    return self._current_engine.get_weapon_essence_counts()
 
             # 否则返回最后一次扫描的数据
             return self._last_weapon_essence_counts.copy()


### PR DESCRIPTION
[x] 我已经阅读并理解了项目的贡献指南（CONTRIBUTING.md）。

## 提交类型（必填）

请确认本 PR 符合以下任意一项：

* [x] **已有 Issue/RFC：** 已关联相关的前置Issue：#136
* [ ] **紧急修复 (Hotfix)：** 修复关键路径或生产环境的严重问题。
* [ ] **需求变更/新功能：** 已经过前期讨论并达成共识。
* [x] **草稿 PR (Draft)：** 仅用于早期思路交流。*注：未事先沟通且不符合项目方向的 PR，可能被直接关闭。*

---

## 🎨 代码风格与质量保证

* [x] **风格一致性：** 我已参考现有代码库的结构与命名习惯，确保新代码与现有风格保持一致。
* [x] **文件组织：** 新增文件已放置在合适的目录下，且文件命名符合规范。
* [ ] **测试覆盖率：** 我为可以测试的功能编写了单元测试。（目前项目的测试覆盖率无强制要求，但多多益善）
* [x] **可读性：** 拒绝臃肿函数和嵌套分支；复杂逻辑块已添加必要的 **行内注释**。
* [x] **命名规范：** 避免使用单字母变量（如 `x`, `y`, `i` 等）。
* [x] **文档：** 新添加或修改的函数、类已包含完整的 **Docstring** 注释。
* [x] **自测通过：** 我已在本地运行并通过了 `pre-commit` 检查。
* [x] **集成测试：** 我通过真实游戏窗口验证了新功能/修复的有效性。

---

## 📝 修改描述

后端：
  - `EvaluationResult` 增加 `matched_non_trash_weapons` 字段用于统计非垃圾武器的基质数量
  - `ScannerEngine` 实现基质数量统计, 按稀有度和武器ID排序输出
  - 统计每个武器匹配到的基质数量输出到日志
  - API：
    - GET /api/scanning_status - 获取扫描状态
    - GET /api/weapon_essence_counts - 获取武器基质数量统计

前端：
  - 增加 useScanningStatus composable 实现扫描状态轮询
  - 设置页武器图标显示基质数量徽章, 扫描过程中轮询更新 (依赖 useScanningStatus)
  - 日志页面按钮根据扫描状态动态显示文本和颜色 (依赖 useScanningStatus)
  - 新增 `启用轮询状态更新` 设置项, 默认禁用

---

## 🧪 验证与测试结果

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d889931e-5f95-40a2-8126-594bcc510fc5" />

~怎么反斜杠还有小开关~

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1b2185fd-5ee9-43dd-87ef-4afc364a49a0" />

<img width="803" height="225" alt="image" src="https://github.com/user-attachments/assets/18074377-e688-46e5-bef0-7c9e561d1024" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/10211ef6-45c8-441c-8c4f-c71aca713fca" />

<img width="562" height="281" alt="image" src="https://github.com/user-attachments/assets/5dca4a1a-9ae8-4b21-a5b2-4f57ec7dca2b" />
