### PR TITLE
fix(updater): 清理残留空目录导致应用无法正常启动的问题

### DIFF
--- a/src/endfield_essence_recognizer/updater/installer.py
+++ b/src/endfield_essence_recognizer/updater/installer.py
@@ -209,6 +209,28 @@ for /F "usebackq delims=" %%F in ("%~dp0_update_temp\\__to_delete.txt") do (
 
 echo   Deleted !delete_count! old files.
 
+REM Clean up empty directories left after file deletion
+echo [4.5/6] Removing empty directories...
+REM First pass: remove immediate parent directories of deleted files
+for /F "usebackq delims=" %%D in ("%~dp0_update_temp\\__to_delete.txt") do (
+    for %%P in ("%~dp0%%D") do (
+        if exist "%%~dpP" (
+            rmdir "%%~dpP" 2>nul
+        )
+    )
+)
+REM Second pass: recursively remove empty directories in _internal
+for /d %%D in ("%~dp0_internal\*") do (
+    rmdir "%%D" 2>nul
+    if exist "%%D" (
+        for /d %%S in ("%%D\*") do (
+            rmdir "%%S" 2>nul
+        )
+        rmdir "%%D" 2>nul
+    )
+)
+echo   Empty directories cleaned.
+
 :copy_files
 echo [5/7] Copying new / updated files from update package...
 


### PR DESCRIPTION
* [x] **紧急修复 (Hotfix)：** 修复关键路径或生产环境的严重问题。

批处理脚本使用 del 命令删除文件，但 del 无法删除目录。
更新后残留的空目录（尤其是旧版本依赖库的目录）
会导致 Python 模块导入混乱，从而引发前后端连接失败。

本次修复添加了两遍目录清理机制：

1.第一遍：rmdir 删除被删除文件的父目录(基于__to_delete.txt)
正常来说不存在../../目录穿越风险（除非有人能控制__to_delete.txt）

2.第二遍：rmdir 递归删除 _internal 目录下的所有空目录
包含了文件的目录不会被删除，不存在误删风险

---

更新时受影响的目录，需要手动删除：
```
_internal/PIL
_internal/httptools
_internal/markupsafe
_internal/watchfiles
_internal/yaml
_internal/endfield_essence_recognizer-0.8.0.dist-info
_internal/email_validator-2.3.0.dist-info
_internal/markupsafe-3.0.3.dist-info
```

如果从0.9.1升级而来，需要手动删除：
```
_internal/endfield_essence_recognizer-0.9.1.dist-info
```
