### PR TITLE
fix: 修复 PyInstaller 打包后 CA 证书缺失导致的崩溃

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -18,6 +18,7 @@ a = Analysis(
     binaries=[],
     datas=[
         *collect_data_files("endfield_essence_recognizer"),
+        *collect_data_files("certifi"),  # 新增：打包 CA 证书
         (
             "frontend/dist",
             "endfield_essence_recognizer/webui_dist",

--- a/src/endfield_essence_recognizer/updater/checker.py
+++ b/src/endfield_essence_recognizer/updater/checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 
+import certifi
 import httpx
 from packaging import version
 
@@ -106,7 +107,9 @@ async def check_for_updates(
         return UpdateCheckError("无法获取当前版本号")
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, proxy=proxy or None) as client:
+        async with httpx.AsyncClient(
+            timeout=10.0, verify=certifi.where(), proxy=proxy or None
+        ) as client:
             response = await client.get(UPDATE_CHECK_URL)
             response.raise_for_status()
             data = response.json()

--- a/src/endfield_essence_recognizer/updater/downloader.py
+++ b/src/endfield_essence_recognizer/updater/downloader.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import aiofiles
+import certifi
 import httpx
 
 from endfield_essence_recognizer.utils.log import logger
@@ -34,7 +35,7 @@ async def download_update(
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
         async with httpx.AsyncClient(
-            timeout=300.0, follow_redirects=True, proxy=proxy
+            timeout=300.0, verify=certifi.where(), follow_redirects=True, proxy=proxy
         ) as client:
             logger.info(f"开始下载更新: {download_url}")
 

--- a/src/endfield_essence_recognizer/utils/http_client.py
+++ b/src/endfield_essence_recognizer/utils/http_client.py
@@ -12,7 +12,9 @@ class HotkeyClient:
         self.base_url = f"http://{config.api_host}:{config.api_port}/api"
         self.client = httpx.Client(
             timeout=5.0,
-            transport=httpx.HTTPTransport(proxy=None),  # 明确禁用代理
+            transport=httpx.HTTPTransport(
+                proxy=None, verify=False
+            ),  # 明确禁用代理，仅与本地 HTTP 服务通信，无需 SSL 验证
         )
 
     def post(


### PR DESCRIPTION
* [x] **紧急修复 (Hotfix)：** 修复关键路径或生产环境的严重问题。

PyInstaller 打包后 httpx 初始化时调用 ssl.create_default_context() 找不到系统 CA 证书包，导致 FileNotFoundError。

- http_client.py: HTTPTransport 添加 verify=False（仅与 localhost 通信）
    > 本地前后端通信 无需ssl验证
- updater/checker.py 和 downloader.py: 使用 certifi.where() 显式指定证书路径
    > 检查更新与下载压缩包 需要ssl验证
- main.spec: 添加 collect_data_files("certifi") 
    > 将 CA 证书打包进发行版

### 问题缘由
v0.7.0版本引入了httpx，在部分windows环境下无CA证书会引发No such file or directory报错

### 问题截图
<img width="43" height="79" alt="image" src="https://github.com/user-attachments/assets/f899e5ba-0cbd-4dc7-9314-efc1c0bafb8f" />