### PR TITLE
fix: 热键注册失败时自动降级，避免应用启动崩溃

### DIFF
--- a/src/endfield_essence_recognizer/hotkey_entrypoints.py
+++ b/src/endfield_essence_recognizer/hotkey_entrypoints.py
@@ -86,16 +86,32 @@ def temp_handle_keyboard_save_screenshot_for_debug(key: str):
     )
 
 
+def _safe_add_hotkey(key, handler, args, fallback=None):
+    try:
+        keyboard.add_hotkey(key, handler, args=args)
+    except Exception:
+        if fallback:
+            try:
+                keyboard.add_hotkey(fallback, handler, args=args)
+                logger.warning(f'热键 "{key}" 注册失败，已替换为 "{fallback}"')
+            except Exception as e:
+                logger.warning(
+                    f'热键 "{key}" 和备用热键 "{fallback}" 均注册失败: {e}，该热键将不可用'
+                )
+        else:
+            logger.warning(f'热键 "{key}" 注册失败，该热键将不可用')
+
+
 @contextmanager
 def bind_hotkeys(server_config: ServerConfig):
     """Context manager to bind and unbind global hotkeys."""
-    keyboard.add_hotkey("[", handle_keyboard_single_recognition, args=("[",))
-    keyboard.add_hotkey("]", handle_keyboard_auto_click, args=("]",))
-    keyboard.add_hotkey("\\", handle_keyboard_delivery_claim, args=("\\",))
-    keyboard.add_hotkey("alt+delete", handle_keyboard_on_exit, args=("alt+delete",))
+    _safe_add_hotkey("[", handle_keyboard_single_recognition, args=("[",), fallback=",")
+    _safe_add_hotkey("]", handle_keyboard_auto_click, args=("]",), fallback=".")
+    _safe_add_hotkey("\\", handle_keyboard_delivery_claim, args=("\\",))
+    _safe_add_hotkey("alt+delete", handle_keyboard_on_exit, args=("alt+delete",))
     if server_config.dev_mode:
         logger.debug("开发模式下，启用截图调试热键 `=`")
-        keyboard.add_hotkey(
+        _safe_add_hotkey(
             "=", temp_handle_keyboard_save_screenshot_for_debug, args=("=",)
         )  # 临时热键，用于调试截图功能
     logger.info("全局热键已注册")


### PR DESCRIPTION
* [x] **紧急修复 (Hotfix)：** 修复关键路径或生产环境的严重问题。

## 问题

当系统键盘布局不支持 `[`、`]` 等按键的扫描码映射时（如非美式键盘布局、自定义固件的客制化键盘等），
`keyboard.add_hotkey()` 会抛出 `ValueError`，导致 FastAPI lifespan 初始化失败，整个应用直接退出。

热键是辅助功能，核心识别能力不依赖热键，不应因热键注册失败而阻断服务启动。

## 修复

1. 提取 `_safe_add_hotkey` 辅助函数，对 `keyboard.add_hotkey` 调用进行异常捕获
2. 为 `[` 和 `]` 设置 fallback 热键（`,` 和 `.`），原键注册失败时自动降级并提示用户
3. 单个热键注册失败仅记录警告日志，不影响其他热键注册和服务正常启动

fallback 键选取 `,` 和 `.` 的原因：在 ANSI/ISO/JIS 主流布局上物理位置一致、
USB HID 扫描码固定（0x36/0x37）、与游戏常用按键无冲突。