### PR TITLE
fix: 修正默认更新源为 GitHub 并修复相关测试

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "endfield-essence-recognizer"
-version = "1.0.1"
+version = "1.0.0"
 description = "不知道哪些基质该留哪些该扔？逝逝这个妙妙小工具吧！"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_user_setting_manager.py
+++ b/tests/test_user_setting_manager.py
@@ -333,7 +333,7 @@ def test_config_migration_chain_v2_to_current():
     assert migrated.fix_grid_row_offset_after_page_flip is True
     assert migrated.fix_page_flip_overscroll is False
     assert migrated.update_mirror == "github"
-    assert migrated.update_flow == "cn_yituliu"
+    assert migrated.update_flow == "github"
     assert migrated.treasure_essence_match_mode == "all"
 
 
@@ -418,7 +418,7 @@ def test_migration_sets_all_required_fields():
     assert migrated.update_mirrorchyan_res_id == ""
     assert migrated.update_mirrorchyan_cdk == ""
     assert migrated.update_mirrorchyan_user_agent == "EER_APP"
-    assert migrated.update_flow == "cn_yituliu"
+    assert migrated.update_flow == "github"
     assert migrated.update_github_mirror == "github"
 
     # v5→v6 补充的字段（宝藏基质匹配和同类型限制）

--- a/tests/unit/updater/test_checker_flows.py
+++ b/tests/unit/updater/test_checker_flows.py
@@ -90,8 +90,13 @@ async def test_yituliu_flow_only_requests_yituliu():
 
 
 @pytest.mark.asyncio
-async def test_mirror_chyan_flow_only_requests_mirror_chyan():
+async def test_mirror_chyan_flow_only_requests_mirror_chyan(monkeypatch):
     """Mirror 酱流程只应请求 Mirror 酱接口。"""
+    # mirror_chyan 在当前版本默认禁用，测试时临时启用以验证独立流程
+    from endfield_essence_recognizer.updater import sources
+
+    monkeypatch.setitem(sources.UPDATE_FLOW_ENABLED, sources.MIRROR_CHYAN_FLOW, True)
+
     mirror_url = checker.MIRROR_CHYAN_LATEST_URL.format(res_id="EER")
     FakeAsyncClient.routes = {
         mirror_url: FakeResponse(

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "endfield-essence-recognizer"
-version = "1.0.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
  - 将默认更新流程从 cn_yituliu 改为 github
  - 修复 mirror_chyan 测试：因当前版本默认禁用，测试时临时启用以验证独立流程
  - 版本回退至 1.0.0

* [x] **紧急修复 (Hotfix)：** 修复关键路径或生产环境的严重问题。