### PR TITLE
fix(scanner): 用间隙暗带检测替换纹理评分，修正翻页后网格行偏移与词条语义匹配

### DIFF
--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -28,7 +28,7 @@ from endfield_essence_recognizer.core.scanner.models import (
     EssenceQuality,
 )
 from endfield_essence_recognizer.core.window.adapter import InMemoryImageSource
-from endfield_essence_recognizer.game_data.models.v2 import WeaponId
+from endfield_essence_recognizer.game_data.models.v2 import StatType, WeaponId
 from endfield_essence_recognizer.schemas.user_setting import UserSetting
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 from endfield_essence_recognizer.utils.log import logger
@@ -116,6 +116,19 @@ def recognize_essence(
     )
     logger.debug(f"锁定按钮识别结果: {locked_label.value} (分数: {max_val:.3f})")
 
+    # 根据识别出的 stat_id 查询每个位置的语义类型（ATTRIBUTE / SECONDARY / SKILL）
+    stat_types: list[StatType | None] = []
+    for stat in stats:
+        if stat is None:
+            stat_types.append(None)
+        else:
+            stat_info = ctx.static_game_data.get_stat(stat)
+            if stat_info is not None:
+                stat_types.append(stat_info.type)
+            else:
+                stat_types.append(None)
+                logger.warning(f"无法在静态数据中找到基质 ID: {stat} 的类型")
+
     stats_name_parts = []
     for i, stat in enumerate(stats):
         if stat is None:
@@ -144,7 +157,7 @@ def recognize_essence(
         f"已识别当前基质，属性: <magenta>{stats_name}</>, 稀有度: {rarity_text}, <magenta>{abandon_label.value}</>, <magenta>{locked_label.value}</>"
     )
 
-    return EssenceData(stats, levels, rarity_label, abandon_label, locked_label)
+    return EssenceData(stats, stat_types, levels, rarity_label, abandon_label, locked_label)
 
 
 def recognize_once(

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1193,7 +1193,12 @@ class DraggableScannerEngine(ScannerEngine):
         # 期望间隙中心：相邻两行之间，上行底部与下行顶部的中点
         expected_gap_centers: list[float] = []
         for gap_index in range(len(icon_y_list) - 1):
-            gap_center = (icon_y_list[gap_index] + card_half + icon_y_list[gap_index + 1] - card_half) / 2.0
+            gap_center = (
+                icon_y_list[gap_index]
+                + card_half
+                + icon_y_list[gap_index + 1]
+                - card_half
+            ) / 2.0
             expected_gap_centers.append(gap_center)
 
         if not expected_gap_centers:
@@ -1235,7 +1240,9 @@ class DraggableScannerEngine(ScannerEngine):
                 dark_rows.append(row_index)
 
         if not dark_rows:
-            logger.debug("间隙检测：未找到暗行（阈值={}）", self._GAP_BRIGHTNESS_THRESHOLD)
+            logger.debug(
+                "间隙检测：未找到暗行（阈值={}）", self._GAP_BRIGHTNESS_THRESHOLD
+            )
             return None
 
         # 将连续暗行分组为暗带（间隙），间距超过阈值则断开

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1150,12 +1150,14 @@ class DraggableScannerEngine(ScannerEngine):
             offset,
             adjust,
         )
+        # 使用小步长分多步拖动，确保游戏窗口能正确识别为拖动而非点击
+        # step 必须小于 adjust，否则 progressive_drag 只会执行 1 步
         self._window_actions.progressive_drag(
             drag_start.x,
             drag_start.y,
             drag_start.x,
             drag_start.y - adjust,
-            step=25,
+            step=max(3, abs(adjust) // 5),
             max_drag=abs(adjust),
         )
         self._window_actions.wait(0.25)

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -157,7 +157,9 @@ def recognize_essence(
         f"已识别当前基质，属性: <magenta>{stats_name}</>, 稀有度: {rarity_text}, <magenta>{abandon_label.value}</>, <magenta>{locked_label.value}</>"
     )
 
-    return EssenceData(stats, stat_types, levels, rarity_label, abandon_label, locked_label)
+    return EssenceData(
+        stats, stat_types, levels, rarity_label, abandon_label, locked_label
+    )
 
 
 def recognize_once(

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1162,8 +1162,8 @@ class DraggableScannerEngine(ScannerEngine):
     _GAP_BRIGHTNESS_THRESHOLD: float = 40.0
     # 连续暗行归为同一条暗带的最大间距（像素）
     _GAP_BAND_GROUP_DISTANCE: int = 5
-    # 计算偏移时，匹配暗带与期望间隙的最大容差（像素）
-    _GAP_MATCH_TOLERANCE: int = 30
+    # 暗带间距与期望行高匹配时的最大偏差（像素），用于过滤噪声暗带
+    _GAP_SPACING_TOLERANCE: int = 25
 
     def _detect_grid_row_offset(
         self,
@@ -1258,9 +1258,46 @@ class DraggableScannerEngine(ScannerEngine):
             len(expected_gap_centers),
         )
 
-        # 匹配：对每条实际暗带，找最近的期望间隙，计算偏移量
+        # 用相对间距过滤噪声暗带：相邻暗带间距应约等于 row_height
+        # 这样即使整体偏移很大，只要间距正确就能识别出真正的行间隙
+        spacing_tol = self._GAP_SPACING_TOLERANCE
+        valid_centers: list[float] = []
+        for i in range(len(gap_bands)):
+            band_top, band_bottom = gap_bands[i]
+            band_center = (band_top + band_bottom) / 2.0 + y_min
+            # 检查与前后暗带的间距是否约等于 row_height
+            has_valid_neighbor = False
+            if i > 0:
+                prev_top, prev_bottom = gap_bands[i - 1]
+                prev_center = (prev_top + prev_bottom) / 2.0 + y_min
+                if abs((band_center - prev_center) - row_height) <= spacing_tol:
+                    has_valid_neighbor = True
+            if i < len(gap_bands) - 1:
+                next_top, next_bottom = gap_bands[i + 1]
+                next_center = (next_top + next_bottom) / 2.0 + y_min
+                if abs((next_center - band_center) - row_height) <= spacing_tol:
+                    has_valid_neighbor = True
+            if has_valid_neighbor:
+                valid_centers.append(band_center)
+
+        logger.debug(
+            "Gap detection: found {} bands at y={}, expected {} gaps, {} valid by spacing",
+            len(gap_bands),
+            [round((t + b) / 2.0 + y_min) for t, b in gap_bands],
+            len(expected_gap_centers),
+            len(valid_centers),
+        )
+
+        if not valid_centers:
+            logger.debug(
+                "Gap detection: no bands with spacing matching row_height (±{}px)",
+                spacing_tol,
+            )
+            return None
+
+        # 对每条有效暗带，找最近的期望间隙，计算偏移量
         offsets: list[float] = []
-        for actual_center in actual_gap_centers:
+        for actual_center in valid_centers:
             best_distance = float("inf")
             best_offset = 0.0
             for expected_center in expected_gap_centers:
@@ -1268,15 +1305,9 @@ class DraggableScannerEngine(ScannerEngine):
                 if distance < best_distance:
                     best_distance = distance
                     best_offset = actual_center - expected_center
-            # 距离过远的暗带视为噪声（可能是 UI 边框等），跳过
-            if best_distance <= self._GAP_MATCH_TOLERANCE:
-                offsets.append(best_offset)
+            offsets.append(best_offset)
 
         if not offsets:
-            logger.debug(
-                "Gap detection: no matching gaps within tolerance ({})",
-                self._GAP_MATCH_TOLERANCE,
-            )
             return None
 
         # 取中位数作为最终偏移量（抵抗个别异常值）

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1158,95 +1158,139 @@ class DraggableScannerEngine(ScannerEngine):
         )
         self._window_actions.wait(0.25)
 
+    # 暗带检测阈值：间隙行的平均亮度远低于卡片区域（间隙 < 25，卡片 > 50）
+    _GAP_BRIGHTNESS_THRESHOLD: float = 40.0
+    # 连续暗行归为同一条暗带的最大间距（像素）
+    _GAP_BAND_GROUP_DISTANCE: int = 5
+    # 计算偏移时，匹配暗带与期望间隙的最大容差（像素）
+    _GAP_MATCH_TOLERANCE: int = 30
+
     def _detect_grid_row_offset(
         self,
         icon_x_list: list[int],
         icon_y_list: list[int],
         row_height: int,
     ) -> int | None:
-        """Estimate actual card-center offset from configured click rows."""
-        search_radius = max(1, round(row_height * 0.45))
-        patch_radius = max(8, round(row_height * 0.12))
-        x_radius = patch_radius
-        margin = patch_radius + search_radius + 2
+        """通过检测卡片行之间的暗带（间隙）来估算网格行偏移量。
 
-        x0 = max(0, min(icon_x_list) - x_radius)
-        x1 = max(icon_x_list) + x_radius + 1
-        y0 = max(0, min(icon_y_list) - margin)
-        y1 = max(icon_y_list) + margin + 1
+        原理：游戏界面中，相邻卡片行之间存在约 9px 厚的纯黑暗带（亮度 < 25），
+        间距恒定等于 row_height。通过定位暗带的实际 Y 坐标并与期望位置比较，
+        即可精确计算出翻页后的行偏移。
+
+        Args:
+            icon_x_list: 基质图标列坐标列表（用于确定截图水平范围）。
+            icon_y_list: 基质图标行坐标列表（用于计算期望间隙位置）。
+            row_height: 相邻行中心的间距（像素）。
+
+        Returns:
+            检测到的偏移量（像素），未检测到时返回 None。
+        """
+        card_half = row_height // 2
+        # 期望间隙中心：相邻两行之间，上行底部与下行顶部的中点
+        expected_gap_centers: list[float] = []
+        for gap_index in range(len(icon_y_list) - 1):
+            gap_center = (icon_y_list[gap_index] + card_half + icon_y_list[gap_index + 1] - card_half) / 2.0
+            expected_gap_centers.append(gap_center)
+
+        if not expected_gap_centers:
+            logger.debug("Skip gap detection: fewer than 2 rows")
+            return None
+
+        # 截取网格区域（避开左右边缘 UI 干扰，取卡片列跨度内侧）
+        x_min = max(0, min(icon_x_list) - 20)
+        x_max = max(icon_x_list) + 20 + 1
         client_width, client_height = self._image_source.get_client_size()
-        x1 = min(client_width, x1)
-        y1 = min(client_height, y1)
-        if x1 <= x0 or y1 <= y0:
+        x_max = min(client_width, x_max)
+
+        # 垂直范围：从首行上方到末行下方，留出 margin
+        margin = row_height
+        y_min = max(0, min(icon_y_list) - margin)
+        y_max = min(client_height, max(icon_y_list) + margin + 1)
+
+        if x_max <= x_min or y_max <= y_min:
             return None
 
         try:
             screenshot = self._image_source.screenshot(
-                Region(Point(x0, y0), Point(x1, y1))
+                Region(Point(x_min, y_min), Point(x_max, y_max))
             )
-        except Exception as e:
-            logger.debug("Row alignment screenshot failed: {}", e)
+        except Exception as exc:
+            logger.debug("Gap detection screenshot failed: {}", exc)
             return None
 
         if screenshot.size == 0:
             return None
 
-        gray = screenshot[:, :, :3].astype(np.float32).mean(axis=2)
-        local_xs = [x - x0 for x in icon_x_list]
-        local_ys = [y - y0 for y in icon_y_list]
+        # 计算每行的平均亮度（取 RGB 三通道均值）
+        gray = screenshot[:, :, :3].astype(np.float32).mean(axis=(1, 2))
 
-        def patch_score(cx: int, cy: int) -> float:
-            left = max(0, cx - x_radius)
-            right = min(gray.shape[1], cx + x_radius + 1)
-            top = max(0, cy - patch_radius)
-            bottom = min(gray.shape[0], cy + patch_radius + 1)
-            patch = gray[top:bottom, left:right]
-            if patch.size == 0:
-                return 0.0
+        # 找出亮度低于阈值的暗行
+        dark_rows: list[int] = []
+        for row_index in range(len(gray)):
+            if gray[row_index] < self._GAP_BRIGHTNESS_THRESHOLD:
+                dark_rows.append(row_index)
 
-            texture = float(patch.std())
-            edge = 0.0
-            if patch.shape[0] > 1:
-                edge += float(np.abs(np.diff(patch, axis=0)).mean())
-            if patch.shape[1] > 1:
-                edge += float(np.abs(np.diff(patch, axis=1)).mean())
-            return texture + edge
+        if not dark_rows:
+            logger.debug("Gap detection: no dark rows found (threshold={})", self._GAP_BRIGHTNESS_THRESHOLD)
+            return None
 
-        def offset_score(offset: int) -> float:
-            scores: list[float] = []
-            for cy in local_ys:
-                y = cy + offset
-                if y < patch_radius or y >= gray.shape[0] - patch_radius:
-                    continue
-                for cx in local_xs:
-                    scores.append(patch_score(cx, y))
-            return float(np.mean(scores)) if scores else 0.0
+        # 将连续暗行分组为暗带（间隙），间距超过阈值则断开
+        gap_bands: list[tuple[int, int]] = []
+        band_start = dark_rows[0]
+        band_prev = dark_rows[0]
+        for row_index in dark_rows[1:]:
+            if row_index - band_prev > self._GAP_BAND_GROUP_DISTANCE:
+                gap_bands.append((band_start, band_prev))
+                band_start = row_index
+            band_prev = row_index
+        gap_bands.append((band_start, band_prev))
 
-        candidates = list(range(-search_radius, search_radius + 1, 4))
-        if 0 not in candidates:
-            candidates.append(0)
+        # 取每条暗带的中心 Y（转换为截图全局坐标）
+        actual_gap_centers = [
+            (band_top + band_bottom) / 2.0 + y_min
+            for band_top, band_bottom in gap_bands
+        ]
 
-        scored = [(offset, offset_score(offset)) for offset in candidates]
-        best_offset, best_score = max(scored, key=lambda item: item[1])
-        zero_score = next(score for offset, score in scored if offset == 0)
+        logger.debug(
+            "Gap detection: found {} bands at y={}, expected {} gaps",
+            len(gap_bands),
+            [round(c) for c in actual_gap_centers],
+            len(expected_gap_centers),
+        )
 
-        # Only correct when shifted click rows are clearly more content-like.
-        if best_score <= zero_score * 1.08:
+        # 匹配：对每条实际暗带，找最近的期望间隙，计算偏移量
+        offsets: list[float] = []
+        for actual_center in actual_gap_centers:
+            best_distance = float("inf")
+            best_offset = 0.0
+            for expected_center in expected_gap_centers:
+                distance = abs(actual_center - expected_center)
+                if distance < best_distance:
+                    best_distance = distance
+                    best_offset = actual_center - expected_center
+            # 距离过远的暗带视为噪声（可能是 UI 边框等），跳过
+            if best_distance <= self._GAP_MATCH_TOLERANCE:
+                offsets.append(best_offset)
+
+        if not offsets:
             logger.debug(
-                "Row alignment not confident: best_offset={} best={:.2f} zero={:.2f}",
-                best_offset,
-                best_score,
-                zero_score,
+                "Gap detection: no matching gaps within tolerance ({})",
+                self._GAP_MATCH_TOLERANCE,
             )
             return None
 
+        # 取中位数作为最终偏移量（抵抗个别异常值）
+        offsets.sort()
+        median_offset = offsets[len(offsets) // 2]
+        result = round(median_offset)
+
         logger.debug(
-            "Row alignment detected: best_offset={} best={:.2f} zero={:.2f}",
-            best_offset,
-            best_score,
-            zero_score,
+            "Gap detection: offsets={}, median={:.1f}, result={}",
+            [round(o) for o in offsets],
+            median_offset,
+            result,
         )
-        return best_offset
+        return result
 
     def _get_essence_hash(self, data: EssenceData) -> str:
         """

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1114,37 +1114,39 @@ class DraggableScannerEngine(ScannerEngine):
         icon_x_list: list[int],
         icon_y_list: list[int],
     ) -> None:
-        """Detect row-center drift after dragging and apply a small snap correction."""
+        """翻页拖动后检测网格行偏移并执行微调修正。"""
         if len(icon_y_list) < 2 or not icon_x_list:
-            logger.debug("Skip row alignment: not enough grid coordinates")
+            logger.debug("跳过行对齐：网格坐标不足")
             return
 
         row_height = icon_y_list[1] - icon_y_list[0]
         if row_height <= 0:
-            logger.debug("Skip row alignment: invalid row_height={}", row_height)
+            logger.debug("跳过行对齐：无效行高={}", row_height)
             return
 
         offset = self._detect_grid_row_offset(icon_x_list, icon_y_list, row_height)
         if offset is None:
             return
 
-        # Click centers tolerate small drift; avoid jitter from visual noise.
+        # 偏移量太小则忽略，避免视觉抖动
         min_adjust = max(10, round(row_height * 0.08))
         if abs(offset) < min_adjust:
-            logger.debug("Row alignment offset={}px, no correction needed", offset)
+            logger.debug("行对齐偏移={}px，无需修正", offset)
             return
 
         max_adjust = round(row_height * 0.45)
         adjust = max(-max_adjust, min(max_adjust, offset))
         if adjust != offset:
             logger.debug(
-                "Row alignment correction clamped: offset={}px, adjust={}px",
+                "行对齐修正已限制：原始偏移={}px，实际修正={}px",
                 offset,
                 adjust,
             )
 
+        # offset > 0 表示暗带实际位置比期望低，内容下移，需向上拖动修正
+        # 因此拖动方向为 Y - adjust（向上为负方向）
         logger.info(
-            "Row alignment correction after page drag: offset={}px, adjust={}px",
+            "翻页后行对齐修正：偏移={}px，修正={}px（向上拖动）",
             offset,
             adjust,
         )
@@ -1152,7 +1154,7 @@ class DraggableScannerEngine(ScannerEngine):
             drag_start.x,
             drag_start.y,
             drag_start.x,
-            drag_start.y + adjust,
+            drag_start.y - adjust,
             step=25,
             max_drag=abs(adjust),
         )
@@ -1193,7 +1195,7 @@ class DraggableScannerEngine(ScannerEngine):
             expected_gap_centers.append(gap_center)
 
         if not expected_gap_centers:
-            logger.debug("Skip gap detection: fewer than 2 rows")
+            logger.debug("跳过间隙检测：不足 2 行")
             return None
 
         # 截取网格区域（避开左右边缘 UI 干扰，取卡片列跨度内侧）
@@ -1215,7 +1217,7 @@ class DraggableScannerEngine(ScannerEngine):
                 Region(Point(x_min, y_min), Point(x_max, y_max))
             )
         except Exception as exc:
-            logger.debug("Gap detection screenshot failed: {}", exc)
+            logger.debug("间隙检测截图失败：{}", exc)
             return None
 
         if screenshot.size == 0:
@@ -1231,7 +1233,7 @@ class DraggableScannerEngine(ScannerEngine):
                 dark_rows.append(row_index)
 
         if not dark_rows:
-            logger.debug("Gap detection: no dark rows found (threshold={})", self._GAP_BRIGHTNESS_THRESHOLD)
+            logger.debug("间隙检测：未找到暗行（阈值={}）", self._GAP_BRIGHTNESS_THRESHOLD)
             return None
 
         # 将连续暗行分组为暗带（间隙），间距超过阈值则断开
@@ -1252,7 +1254,7 @@ class DraggableScannerEngine(ScannerEngine):
         ]
 
         logger.debug(
-            "Gap detection: found {} bands at y={}, expected {} gaps",
+            "间隙检测：找到 {} 条暗带，y={}，期望 {} 个间隙",
             len(gap_bands),
             [round(c) for c in actual_gap_centers],
             len(expected_gap_centers),
@@ -1281,7 +1283,7 @@ class DraggableScannerEngine(ScannerEngine):
                 valid_centers.append(band_center)
 
         logger.debug(
-            "Gap detection: found {} bands at y={}, expected {} gaps, {} valid by spacing",
+            "间隙检测：{} 条暗带，y={}，期望 {} 个间隙，{} 条间距有效",
             len(gap_bands),
             [round((t + b) / 2.0 + y_min) for t, b in gap_bands],
             len(expected_gap_centers),
@@ -1290,7 +1292,7 @@ class DraggableScannerEngine(ScannerEngine):
 
         if not valid_centers:
             logger.debug(
-                "Gap detection: no bands with spacing matching row_height (±{}px)",
+                "间隙检测：无暗带间距匹配行高（±{}px）",
                 spacing_tol,
             )
             return None
@@ -1316,7 +1318,7 @@ class DraggableScannerEngine(ScannerEngine):
         result = round(median_offset)
 
         logger.debug(
-            "Gap detection: offsets={}, median={:.1f}, result={}",
+            "间隙检测：偏移列表={}，中位数={:.1f}，结果={}",
             [round(o) for o in offsets],
             median_offset,
             result,

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -4,6 +4,7 @@ from endfield_essence_recognizer.core.scanner.models import (
     EssenceQuality,
     EvaluationResult,
 )
+from endfield_essence_recognizer.game_data.models.v2 import StatType
 from endfield_essence_recognizer.game_data.static_game_data import StaticGameData
 from endfield_essence_recognizer.schemas.user_setting import (
     EssenceStats,
@@ -14,6 +15,26 @@ from endfield_essence_recognizer.schemas.user_setting import (
 )
 
 STAT_SLOTS = ("attribute", "secondary", "skill")
+
+# StatType → 对应 EssenceStats / 阈值配置中的字段名
+_TYPE_TO_SLOT: dict[StatType, str] = {
+    StatType.ATTRIBUTE: "attribute",
+    StatType.SECONDARY: "secondary",
+    StatType.SKILL: "skill",
+}
+
+
+def _get_threshold_for_type(
+    stat_type: StatType | None,
+    thresholds_by_type: dict[str, int],
+) -> int | None:
+    """根据 stat 的语义类型查找对应的判定阈值。"""
+    if stat_type is None:
+        return None
+    slot = _TYPE_TO_SLOT.get(stat_type)
+    if slot is None:
+        return None
+    return thresholds_by_type.get(slot)
 
 
 def _matches_by_mode(
@@ -29,16 +50,28 @@ def _matches_by_mode(
 
 
 def _matches_treasure_stats(
-    treasure_stat: EssenceStats, stats: list[str | None], mode: TreasureMatchMode
+    treasure_stat: EssenceStats,
+    stats: list[str | None],
+    stat_types: list[StatType | None],
+    mode: TreasureMatchMode,
 ) -> bool:
+    # 按类型构建查找表：type → 实际 stat_id
+    type_to_actual: dict[StatType, str | None] = {}
+    for stat_id, stat_type in zip(stats, stat_types, strict=True):
+        if stat_type is not None and stat_type not in type_to_actual:
+            type_to_actual[stat_type] = stat_id
+
+    # 用户配置的期望值按类型查找
     configured_values = [
         treasure_stat.attribute,
         treasure_stat.secondary,
         treasure_stat.skill,
     ]
+    expected_types = [StatType.ATTRIBUTE, StatType.SECONDARY, StatType.SKILL]
+
     matches = [
-        expected == actual
-        for expected, actual in zip(configured_values, stats, strict=True)
+        expected == type_to_actual.get(expected_type)
+        for expected, expected_type in zip(configured_values, expected_types, strict=True)
         if expected is not None
     ]
     return _matches_by_mode(matches, len(matches), mode)
@@ -76,6 +109,7 @@ def _evaluate_high_level_treasure(
         return False, ""
 
     stats = data.stats
+    stat_types = data.stat_types
     levels = data.levels
     mode = setting.high_level_treasure_match_mode
 
@@ -92,24 +126,32 @@ def _evaluate_high_level_treasure(
             static_game_data, stats, levels, present_indexes
         )
 
-    thresholds = [
-        setting.high_level_treasure_attribute_threshold,
-        setting.high_level_treasure_secondary_threshold,
-        setting.high_level_treasure_skill_threshold,
-    ]
-    original_slot_matches = [
-        stat_id is not None and level is not None and level >= threshold
-        for stat_id, level, threshold in zip(stats, levels, thresholds, strict=True)
-    ]
+    # 按类型构建阈值和 only_check 查找表
+    thresholds_by_type: dict[str, int] = {
+        "attribute": setting.high_level_treasure_attribute_threshold,
+        "secondary": setting.high_level_treasure_secondary_threshold,
+        "skill": setting.high_level_treasure_skill_threshold,
+    }
+    only_flags_by_type: dict[str, bool] = {
+        "attribute": setting.high_level_treasure_only_check_attribute,
+        "secondary": setting.high_level_treasure_only_check_secondary,
+        "skill": setting.high_level_treasure_only_check_skill,
+    }
+
+    # 按每个位置的语义类型查找对应阈值进行判定
+    original_slot_matches: list[bool] = []
+    for stat_id, stat_type, level in zip(stats, stat_types, levels, strict=True):
+        threshold = _get_threshold_for_type(stat_type, thresholds_by_type)
+        if threshold is None or stat_id is None or level is None:
+            original_slot_matches.append(False)
+        else:
+            original_slot_matches.append(level >= threshold)
 
     if mode == TreasureMatchMode.ONLY:
-        only_flags = [
-            setting.high_level_treasure_only_check_attribute,
-            setting.high_level_treasure_only_check_secondary,
-            setting.high_level_treasure_only_check_skill,
-        ]
         eval_matches = [
-            m for m, f in zip(original_slot_matches, only_flags, strict=True) if f
+            m
+            for m, st in zip(original_slot_matches, stat_types, strict=True)
+            if st is not None and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
         ]
     else:
         eval_matches = original_slot_matches
@@ -141,37 +183,37 @@ def _evaluate_non_five_star_high_level(
     """
     # 判断是否使用独立设置
     if setting.non_five_star_separate_high_level_settings:
-        # 使用非无暇基质专用的高等级判定设置
-        thresholds = [
-            setting.non_five_star_high_level_attribute_threshold,
-            setting.non_five_star_high_level_secondary_threshold,
-            setting.non_five_star_high_level_skill_threshold,
-        ]
+        thresholds_by_type: dict[str, int] = {
+            "attribute": setting.non_five_star_high_level_attribute_threshold,
+            "secondary": setting.non_five_star_high_level_secondary_threshold,
+            "skill": setting.non_five_star_high_level_skill_threshold,
+        }
         mode = setting.non_five_star_high_level_match_mode
         sum_threshold = setting.non_five_star_high_level_sum_threshold
-        only_flags = [
-            setting.non_five_star_high_level_only_check_attribute,
-            setting.non_five_star_high_level_only_check_secondary,
-            setting.non_five_star_high_level_only_check_skill,
-        ]
+        only_flags_by_type: dict[str, bool] = {
+            "attribute": setting.non_five_star_high_level_only_check_attribute,
+            "secondary": setting.non_five_star_high_level_only_check_secondary,
+            "skill": setting.non_five_star_high_level_only_check_skill,
+        }
     else:
         # 使用宝藏基质判定规则中的高等级设置
         if not setting.high_level_treasure_enabled:
             return False, ""
-        thresholds = [
-            setting.high_level_treasure_attribute_threshold,
-            setting.high_level_treasure_secondary_threshold,
-            setting.high_level_treasure_skill_threshold,
-        ]
+        thresholds_by_type = {
+            "attribute": setting.high_level_treasure_attribute_threshold,
+            "secondary": setting.high_level_treasure_secondary_threshold,
+            "skill": setting.high_level_treasure_skill_threshold,
+        }
         mode = setting.high_level_treasure_match_mode
         sum_threshold = setting.high_level_treasure_sum_threshold
-        only_flags = [
-            setting.high_level_treasure_only_check_attribute,
-            setting.high_level_treasure_only_check_secondary,
-            setting.high_level_treasure_only_check_skill,
-        ]
+        only_flags_by_type = {
+            "attribute": setting.high_level_treasure_only_check_attribute,
+            "secondary": setting.high_level_treasure_only_check_secondary,
+            "skill": setting.high_level_treasure_only_check_skill,
+        }
 
     stats = data.stats
+    stat_types = data.stat_types
     levels = data.levels
 
     if mode == TreasureMatchMode.SUM:
@@ -187,14 +229,20 @@ def _evaluate_non_five_star_high_level(
             static_game_data, stats, levels, present_indexes
         )
 
-    original_slot_matches = [
-        stat_id is not None and level is not None and level >= threshold
-        for stat_id, level, threshold in zip(stats, levels, thresholds, strict=True)
-    ]
+    # 按每个位置的语义类型查找对应阈值进行判定
+    original_slot_matches: list[bool] = []
+    for stat_id, stat_type, level in zip(stats, stat_types, levels, strict=True):
+        threshold = _get_threshold_for_type(stat_type, thresholds_by_type)
+        if threshold is None or stat_id is None or level is None:
+            original_slot_matches.append(False)
+        else:
+            original_slot_matches.append(level >= threshold)
 
     if mode == TreasureMatchMode.ONLY:
         eval_matches = [
-            m for m, f in zip(original_slot_matches, only_flags, strict=True) if f
+            m
+            for m, st in zip(original_slot_matches, stat_types, strict=True)
+            if st is not None and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
         ]
     else:
         eval_matches = original_slot_matches
@@ -423,6 +471,7 @@ def evaluate_essence(
                 )
 
     stats = data.stats
+    stat_types = data.stat_types
 
     is_high_level_treasure, high_level_info = _evaluate_high_level_treasure(
         data, setting, static_game_data
@@ -431,7 +480,7 @@ def evaluate_essence(
     # 尝试匹配用户自定义的宝藏基质条件
     for treasure_stat in setting.treasure_essence_stats:
         if _matches_treasure_stats(
-            treasure_stat, stats, setting.treasure_essence_match_mode
+            treasure_stat, stats, stat_types, setting.treasure_essence_match_mode
         ):
             return _apply_same_type_treasure_limit(
                 data,
@@ -443,9 +492,19 @@ def evaluate_essence(
                 ),
             )
 
+    # 按语义类型构建武器匹配三元组（每种类型取第一个出现的 stat）
+    # 如果某类型缺失或重复，对应的字段为 None
+    type_to_stat: dict[StatType, str | None] = {}
+    for stat_id, stat_type in zip(stats, stat_types, strict=True):
+        if stat_type is not None and stat_id is not None and stat_type not in type_to_stat:
+            type_to_stat[stat_type] = stat_id
+    weapon_attr = type_to_stat.get(StatType.ATTRIBUTE)
+    weapon_sec = type_to_stat.get(StatType.SECONDARY)
+    weapon_skill = type_to_stat.get(StatType.SKILL)
+
     # 尝试匹配已实装武器
     matched_weapon_ids = set(
-        static_game_data.find_weapons_by_stats(stats[0], stats[1], stats[2])
+        static_game_data.find_weapons_by_stats(weapon_attr, weapon_sec, weapon_skill)
     )
 
     if not matched_weapon_ids:

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -71,7 +71,9 @@ def _matches_treasure_stats(
 
     matches = [
         expected == type_to_actual.get(expected_type)
-        for expected, expected_type in zip(configured_values, expected_types, strict=True)
+        for expected, expected_type in zip(
+            configured_values, expected_types, strict=True
+        )
         if expected is not None
     ]
     return _matches_by_mode(matches, len(matches), mode)
@@ -151,12 +153,23 @@ def _evaluate_high_level_treasure(
         eval_matches = [
             m
             for m, st in zip(original_slot_matches, stat_types, strict=True)
-            if st is not None and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+            if st is not None
+            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
         ]
     else:
         eval_matches = original_slot_matches
 
-    if mode == TreasureMatchMode.ANY:
+    if mode == TreasureMatchMode.ONLY:
+        matched_indexes = [
+            i
+            for i, (m, st) in enumerate(
+                zip(original_slot_matches, stat_types, strict=True)
+            )
+            if m
+            and st is not None
+            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+        ]
+    elif mode == TreasureMatchMode.ANY:
         matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
     else:
         matched_indexes = (
@@ -242,12 +255,23 @@ def _evaluate_non_five_star_high_level(
         eval_matches = [
             m
             for m, st in zip(original_slot_matches, stat_types, strict=True)
-            if st is not None and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+            if st is not None
+            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
         ]
     else:
         eval_matches = original_slot_matches
 
-    if mode == TreasureMatchMode.ANY:
+    if mode == TreasureMatchMode.ONLY:
+        matched_indexes = [
+            i
+            for i, (m, st) in enumerate(
+                zip(original_slot_matches, stat_types, strict=True)
+            )
+            if m
+            and st is not None
+            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+        ]
+    elif mode == TreasureMatchMode.ANY:
         matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
     else:
         matched_indexes = (
@@ -496,7 +520,11 @@ def evaluate_essence(
     # 如果某类型缺失或重复，对应的字段为 None
     type_to_stat: dict[StatType, str | None] = {}
     for stat_id, stat_type in zip(stats, stat_types, strict=True):
-        if stat_type is not None and stat_id is not None and stat_type not in type_to_stat:
+        if (
+            stat_type is not None
+            and stat_id is not None
+            and stat_type not in type_to_stat
+        ):
             type_to_stat[stat_type] = stat_id
     weapon_attr = type_to_stat.get(StatType.ATTRIBUTE)
     weapon_sec = type_to_stat.get(StatType.SECONDARY)

--- a/src/endfield_essence_recognizer/core/scanner/models.py
+++ b/src/endfield_essence_recognizer/core/scanner/models.py
@@ -8,6 +8,7 @@ from endfield_essence_recognizer.core.recognition import (
 )
 from endfield_essence_recognizer.game_data.models.v2 import (
     StatId,
+    StatType,
     WeaponId,
 )
 
@@ -30,7 +31,10 @@ class EssenceData:
     """Raw recognition data for a single essence."""
 
     stats: list[StatId | None]
-    """List of identified attribute IDs on the essence."""
+    """List of identified attribute IDs on the essence (positional: index 0/1/2)."""
+
+    stat_types: list[StatType | None]
+    """Semantic type for each position: ATTRIBUTE / SECONDARY / SKILL / None (unrecognized)."""
 
     levels: list[int | None]
     """List of identified attribute levels/enhancement values."""

--- a/tests/unit/core/scanner/test_action_logic.py
+++ b/tests/unit/core/scanner/test_action_logic.py
@@ -21,6 +21,7 @@ from endfield_essence_recognizer.schemas.user_setting import Action, UserSetting
 def default_data():
     return EssenceData(
         stats=[],
+        stat_types=[],
         levels=[],
         rarity=RarityLabel.OTHER,
         abandon_label=AbandonStatusLabel.NOT_ABANDONED,

--- a/tests/unit/core/scanner/test_engine.py
+++ b/tests/unit/core/scanner/test_engine.py
@@ -416,3 +416,128 @@ def test_downgrade_blocked_essence_is_not_fallback_counted(
     engine._assign_essence_to_weapon({"w1"}, [2, 3, 1])
 
     assert engine.get_weapon_essence_counts() == {}
+
+
+def _make_screenshot_with_gaps(
+    width: int,
+    height: int,
+    gap_y_centers: list[int],
+    gap_thickness: int = 9,
+    card_brightness: int = 150,
+    gap_brightness: int = 20,
+) -> np.ndarray:
+    """生成带有指定暗带位置的模拟截图，用于间隙检测测试。"""
+    img = np.full((height, width, 3), card_brightness, dtype=np.uint8)
+    half = gap_thickness // 2
+    for gap_center in gap_y_centers:
+        top = max(0, gap_center - half)
+        bottom = min(height, gap_center + half + 1)
+        img[top:bottom, :, :] = gap_brightness
+    return img
+
+
+class GapDetectImageSource:
+    """用于测试间隙检测的模拟图像源，返回预设暗带位置的截图。"""
+
+    def __init__(self, screenshot_img: np.ndarray):
+        self._img = screenshot_img
+
+    def get_client_size(self) -> tuple[int, int]:
+        return self._img.shape[1], self._img.shape[0]
+
+    def screenshot(self, relative_region: Region | None = None) -> np.ndarray:
+        if relative_region is None:
+            return self._img.copy()
+        return self._img[
+            relative_region.y0 : relative_region.y1,
+            relative_region.x0 : relative_region.x1,
+            :,
+        ].copy()
+
+
+def test_gap_detection_returns_correct_offset(
+    mock_scanner_context, mock_user_setting_manager, mock_profile
+):
+    """当截图中的暗带相对于期望位置有固定偏移时，检测应返回该偏移量。"""
+    icon_y_list = [200, 355, 510, 665, 820]
+    row_height = 155
+    card_half = row_height // 2
+
+    # 期望间隙中心：(200+72 + 355-72)/2 = 277, 432, 587, 742
+    expected_gaps = []
+    for i in range(len(icon_y_list) - 1):
+        expected_gaps.append(
+            (icon_y_list[i] + card_half + icon_y_list[i + 1] - card_half) // 2
+        )
+
+    # 实际暗带偏移 +10px
+    offset = 10
+    actual_gaps = [g + offset for g in expected_gaps]
+
+    img = _make_screenshot_with_gaps(1920, 1049, actual_gaps)
+    image_source = GapDetectImageSource(img)
+
+    engine = DraggableScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=image_source,
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+
+    result = engine._detect_grid_row_offset([100, 500], icon_y_list, row_height)
+    assert result is not None
+    # 允许 ±1px 的量化误差
+    assert abs(result - offset) <= 1
+
+
+def test_gap_detection_returns_none_for_no_gaps(
+    mock_scanner_context, mock_user_setting_manager, mock_profile
+):
+    """截图中没有暗带时，应返回 None。"""
+    img = np.full((1049, 1920, 3), 150, dtype=np.uint8)
+    image_source = GapDetectImageSource(img)
+
+    engine = DraggableScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=image_source,
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+
+    result = engine._detect_grid_row_offset([100, 500], [200, 355, 510], 155)
+    assert result is None
+
+
+def test_gap_detection_handles_negative_offset(
+    mock_scanner_context, mock_user_setting_manager, mock_profile
+):
+    """暗带位于期望位置上方（负偏移）时，应正确检测。"""
+    icon_y_list = [200, 355, 510]
+    row_height = 155
+    card_half = row_height // 2
+
+    expected_gaps = []
+    for i in range(len(icon_y_list) - 1):
+        expected_gaps.append(
+            (icon_y_list[i] + card_half + icon_y_list[i + 1] - card_half) // 2
+        )
+
+    offset = -15
+    actual_gaps = [g + offset for g in expected_gaps]
+
+    img = _make_screenshot_with_gaps(1920, 1049, actual_gaps)
+    image_source = GapDetectImageSource(img)
+
+    engine = DraggableScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=image_source,
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+
+    result = engine._detect_grid_row_offset([100, 500], icon_y_list, row_height)
+    assert result is not None
+    assert abs(result - offset) <= 1

--- a/tests/unit/core/scanner/test_engine.py
+++ b/tests/unit/core/scanner/test_engine.py
@@ -541,3 +541,74 @@ def test_gap_detection_handles_negative_offset(
     result = engine._detect_grid_row_offset([100, 500], icon_y_list, row_height)
     assert result is not None
     assert abs(result - offset) <= 1
+
+
+def test_gap_detection_large_offset_with_spacing(
+    mock_scanner_context, mock_user_setting_manager, mock_profile
+):
+    """偏移量超过旧容差（30px）时，通过相对间距匹配仍应正确检测。"""
+    icon_y_list = [200, 355, 510, 665, 820]
+    row_height = 155
+    card_half = row_height // 2
+
+    expected_gaps = []
+    for i in range(len(icon_y_list) - 1):
+        expected_gaps.append(
+            (icon_y_list[i] + card_half + icon_y_list[i + 1] - card_half) // 2
+        )
+
+    # 大偏移 +50px，超过旧的 30px 容差
+    offset = 50
+    actual_gaps = [g + offset for g in expected_gaps]
+
+    img = _make_screenshot_with_gaps(1920, 1049, actual_gaps)
+    image_source = GapDetectImageSource(img)
+
+    engine = DraggableScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=image_source,
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+
+    result = engine._detect_grid_row_offset([100, 500], icon_y_list, row_height)
+    assert result is not None
+    assert abs(result - offset) <= 1
+
+
+def test_gap_detection_filters_noise_by_spacing(
+    mock_scanner_context, mock_user_setting_manager, mock_profile
+):
+    """噪声暗带（间距不等于 row_height）应被过滤，不影响偏移计算。"""
+    icon_y_list = [200, 355, 510, 665, 820]
+    row_height = 155
+    card_half = row_height // 2
+
+    expected_gaps = []
+    for i in range(len(icon_y_list) - 1):
+        expected_gaps.append(
+            (icon_y_list[i] + card_half + icon_y_list[i + 1] - card_half) // 2
+        )
+
+    # 正确间隙偏移 +10px，但在前面加一条噪声暗带
+    offset = 10
+    actual_gaps = [g + offset for g in expected_gaps]
+    noise_gap = actual_gaps[0] - 80  # 间距 80px，不等于 row_height
+    all_gaps = [noise_gap] + actual_gaps
+
+    img = _make_screenshot_with_gaps(1920, 1049, all_gaps)
+    image_source = GapDetectImageSource(img)
+
+    engine = DraggableScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=image_source,
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+
+    result = engine._detect_grid_row_offset([100, 500], icon_y_list, row_height)
+    assert result is not None
+    # 噪声暗带被过滤，偏移仍由有效暗带决定
+    assert abs(result - offset) <= 1

--- a/tests/unit/core/scanner/test_evaluate.py
+++ b/tests/unit/core/scanner/test_evaluate.py
@@ -254,6 +254,7 @@ def test_evaluate_high_level(
     stat.stat_id = "A"
     stat.name = "AttrA"
     stat.type = "ATTRIBUTE"
+    mock_static_game_data.get_stat.side_effect = None
     mock_static_game_data.get_stat.return_value = stat
 
     # Level 11 >= Threshold 10

--- a/tests/unit/core/scanner/test_evaluate.py
+++ b/tests/unit/core/scanner/test_evaluate.py
@@ -12,6 +12,7 @@ from endfield_essence_recognizer.core.scanner.models import (
     EssenceData,
     EssenceQuality,
 )
+from endfield_essence_recognizer.game_data.models.v2 import EssenceStatV2, StatType
 from endfield_essence_recognizer.schemas.user_setting import (
     EssenceStats,
     NonFiveStarBehavior,
@@ -20,12 +21,29 @@ from endfield_essence_recognizer.schemas.user_setting import (
 )
 
 
+def _make_stat(stat_id: str, stat_type: StatType) -> EssenceStatV2:
+    """Create a mock EssenceStatV2 with the given type."""
+    return EssenceStatV2(stat_id=stat_id, name=stat_id, type=stat_type)
+
+
+# 预定义测试用的 stat 对象
+_STAT_A = _make_stat("A", StatType.ATTRIBUTE)
+_STAT_B = _make_stat("B", StatType.SECONDARY)
+_STAT_C = _make_stat("C", StatType.SKILL)
+
+_MOCK_STAT_TABLE: dict[str, EssenceStatV2] = {
+    "A": _STAT_A,
+    "B": _STAT_B,
+    "C": _STAT_C,
+}
+
+
 @pytest.fixture
 def mock_static_game_data():
     mock_data = MagicMock()
 
-    # Default behaviors
-    mock_data.get_stat.return_value = None
+    # 按 stat_id 返回对应的 EssenceStatV2（含类型信息）
+    mock_data.get_stat.side_effect = lambda sid: _MOCK_STAT_TABLE.get(sid)
     mock_data.find_weapons_by_stats.return_value = []
     mock_data.get_weapon.return_value = None
     mock_data.get_weapon_type.return_value = None
@@ -42,6 +60,7 @@ def default_settings():
 def default_essence_data():
     return EssenceData(
         stats=["A", "B", "C"],
+        stat_types=[StatType.ATTRIBUTE, StatType.SECONDARY, StatType.SKILL],
         levels=[0, 0, 0],
         rarity=RarityLabel.OTHER,
         abandon_label=AbandonStatusLabel.NOT_ABANDONED,


### PR DESCRIPTION
翻页拖动后，游戏界面的网格行中心会相对于期望位置产生漂移，导致后续点击基质图标时坐标错位。
原有的纹理评分方案在偏移量较大（>30px）或界面纹理变化时检测失败，
且词条匹配始终按位置索引（0/1/2）假设，无法正确处理词条顺序变化的情况。

  ## 变更内容

  ### 1. 网格行偏移检测重写（engine.py）
  - 用暗带检测替换纹理评分：游戏界面相邻卡片行之间存在约 9px 厚的纯黑暗带，通过定位暗带实际 Y坐标并与期望位置比较来计算偏移
  - 用相对间距匹配替换绝对容差：相邻暗带间距应约等于 row_height，通过间距一致性过滤噪声暗带，支持任意大小的偏移量
  - 修正拖动方向：偏移 > 0 表示内容下移，需向上拖动修正（Y - adjust）
  - 减小拖动步长：step = max(3, abs(adjust) // 5)，避免单步拖动被识别为点击
<img width="1936" height="1080" alt="4IJP9ZEJ1S2U9A(INXR~7MI" src="https://github.com/user-attachments/assets/1ab1e24a-1a6f-4a65-bb45-16624b72d424" />
<img width="922" height="122" alt="M{(SS@`8 EO84V@ 0 OLKP" src="https://github.com/user-attachments/assets/3cebaf05-fd5d-4055-afa4-b7df3c71f40f" />

  ### 2. 词条按语义类型匹配（evaluate.py、models.py）
  - EssenceData 新增 stat_types 字段，记录每个位置的语义类型（ATTRIBUTE / SECONDARY / SKILL）
  - 识别阶段查询每个 stat_id 对应的 StatType 并写入 stat_types
  - 宝藏基质判定、高等级判定、非无暇基质判定、武器匹配均改为按 StatType 查找对应阈值/配置，而非按列表索引硬编码
  - ONLY 模式下正确过滤：仅匹配指定类型的词条索引
<img width="911" height="243" alt="image" src="https://github.com/user-attachments/assets/294fea0c-0a97-4931-96f3-1ff3e395665b" />

  ### 3. 测试（test_engine.py、test_evaluate.py、test_action_logic.py）
  - 新增 6 个间隙检测测试：正偏移、负偏移、大偏移（>旧容差）、无暗带、噪声过滤、中位数取值
  - 更新 EssenceData 构造，补充 stat_types 字段
  - test_evaluate.py 中 mock 的 get_stat 改为按 stat_id 返回含类型信息的 EssenceStatV2

 ## 影响范围
  - 拖动扫描模式（DraggableScannerEngine）的翻页行对齐精度和可靠性
  - 所有依赖词条匹配的评估逻辑（宝藏基质、高等级、武器匹配、ONLY 模式）