### PR TITLE
feat: 武器属性悬浮面板 及 拖拽翻页末尾行漏扫修正

### DIFF
--- a/frontend/src/components/WeaponOverview.vue
+++ b/frontend/src/components/WeaponOverview.vue
@@ -90,18 +90,26 @@
             @click="showWeaponDetail(entry.syntheticId)"
             @contextmenu.prevent="toggleWeaponOwnership(entry.syntheticId)"
           >
-            <div
-              class="weapon-icon-wrapper"
-              :class="{
-                'weapon-not-owned': !isWeaponOwned(entry.syntheticId),
-                'weapon-maxed': isWeaponMaxed(entry.syntheticId),
-              }"
-            >
-              <custom-stat-icon :name="entry.displayName" />
+            <!-- 武器悬浮面板：显示自定义基质的三条属性 -->
+            <v-tooltip location="top" open-delay="0">
+              <template #activator="{ props }">
+                <div v-bind="props" class="h-100">
+                  <div
+                    class="weapon-icon-wrapper"
+                    :class="{
+                      'weapon-not-owned': !isWeaponOwned(entry.syntheticId),
+                      'weapon-maxed': isWeaponMaxed(entry.syntheticId),
+                    }"
+                  >
+                    <custom-stat-icon :name="entry.displayName" />
 
-              <!-- 满级的彩虹边框 -->
-              <div v-if="isWeaponMaxed(entry.syntheticId)" class="rainbow-border" />
-            </div>
+                    <!-- 满级的彩虹边框 -->
+                    <div v-if="isWeaponMaxed(entry.syntheticId)" class="rainbow-border" />
+                  </div>
+                </div>
+              </template>
+              <span>{{ getWeaponStatsText(entry.syntheticId) }}</span>
+            </v-tooltip>
           </div>
         </div>
       </template>
@@ -123,19 +131,27 @@
             @click="showWeaponDetail(weaponId)"
             @contextmenu.prevent="toggleWeaponOwnership(weaponId)"
           >
-            <div
-              class="weapon-icon-wrapper"
-              :class="{
-                'weapon-not-owned': !isWeaponOwned(weaponId),
-                'weapon-maxed': isWeaponMaxed(weaponId),
-                'switch-target-maxed': isSwitchable(weaponId) && isSwitchTargetMaxed(weaponId),
-              }"
-            >
-              <item-icon :item-id="weaponId" show-item-name />
+            <!-- 武器悬浮面板：显示武器的三条基质属性 -->
+            <v-tooltip location="top" open-delay="0">
+              <template #activator="{ props }">
+                <div v-bind="props" class="h-100">
+                  <div
+                    class="weapon-icon-wrapper"
+                    :class="{
+                      'weapon-not-owned': !isWeaponOwned(weaponId),
+                      'weapon-maxed': isWeaponMaxed(weaponId),
+                      'switch-target-maxed': isSwitchable(weaponId) && isSwitchTargetMaxed(weaponId),
+                    }"
+                  >
+                    <item-icon :item-id="weaponId" show-item-name />
 
-              <!-- 满级的彩虹边框 -->
-              <div v-if="isWeaponMaxed(weaponId)" class="rainbow-border" />
-            </div>
+                    <!-- 满级的彩虹边框 -->
+                    <div v-if="isWeaponMaxed(weaponId)" class="rainbow-border" />
+                  </div>
+                </div>
+              </template>
+              <span>{{ getWeaponStatsText(weaponId) }}</span>
+            </v-tooltip>
 
             <!-- 可切换标记放在灰色滤镜容器外，避免被 opacity/filter 叠加 -->
             <v-chip
@@ -317,7 +333,7 @@ import { useRarityFilters } from '@/composables/useRarityFilters'
 import { useStaticData } from '@/utils/gameData/staticData'
 import { getGemTagName } from '@/utils/gameData/weapon'
 
-const { weaponTypes, weaponsMap } = useStaticData()
+const { weaponTypes, weaponsMap, essencesMap } = useStaticData()
 const {
   activeProfile,
   treasureMatrix,

--- a/frontend/src/pages/matrix-planner.vue
+++ b/frontend/src/pages/matrix-planner.vue
@@ -66,10 +66,18 @@
                                 'weapon-matched': selectedWeaponForLocation === weaponId
                               }"
                             >
-                              <custom-stat-icon v-if="isCustomStatId(weaponId)" :name="getCustomStatDisplayName(weaponId)" small />
-                              <template v-else>
-                                <item-icon :item-id="weaponId" show-item-name />
-                              </template>
+                              <!-- 武器悬浮面板：显示武器的三条基质属性 -->
+                              <v-tooltip location="top" open-delay="0">
+                                <template #activator="{ props }">
+                                  <div v-bind="props" class="h-100">
+                                    <custom-stat-icon v-if="isCustomStatId(weaponId)" :name="getCustomStatDisplayName(weaponId)" small />
+                                    <template v-else>
+                                      <item-icon :item-id="weaponId" show-item-name />
+                                    </template>
+                                  </div>
+                                </template>
+                                <span>{{ getWeaponTooltipText(weaponId) }}</span>
+                              </v-tooltip>
                               <v-chip
                                 v-if="isWeaponObtained(weaponId)"
                                 class="obtained-badge"
@@ -186,8 +194,16 @@
                                     'weapon-obtained': isWeaponObtained(weaponId)
                                   }"
                                 >
-                                  <custom-stat-icon v-if="isCustomStatId(weaponId)" :name="getCustomStatDisplayName(weaponId)" small />
-                                  <item-icon v-else :item-id="weaponId" show-item-name />
+                                  <!-- 武器悬浮面板：显示武器的三条基质属性 -->
+                                  <v-tooltip location="top" open-delay="0">
+                                    <template #activator="{ props }">
+                                      <div v-bind="props" class="h-100">
+                                        <custom-stat-icon v-if="isCustomStatId(weaponId)" :name="getCustomStatDisplayName(weaponId)" small />
+                                        <item-icon v-else :item-id="weaponId" show-item-name />
+                                      </div>
+                                    </template>
+                                    <span>{{ getWeaponTooltipText(weaponId) }}</span>
+                                  </v-tooltip>
                                   <v-chip
                                     v-if="isWeaponObtained(weaponId)"
                                     class="obtained-badge"
@@ -855,6 +871,21 @@ function getRequirementTooltip(index: number): string {
 
 function isCustomStatId(id: string): boolean {
   return id.startsWith('custom_stat_')
+}
+
+/**
+ * 获取武器的悬浮面板文本，支持普通武器和自定义基质
+ * 普通武器从 weaponsMap 中获取三条基质属性名称
+ * 自定义基质从 customStats 配置中获取属性名称
+ */
+function getWeaponTooltipText(weaponId: string): string {
+  if (isCustomStatId(weaponId)) {
+    const match = weaponId.match(/^custom_stat_(\d+)$/)
+    if (!match) return ''
+    const index = Number.parseInt(match[1]!, 10)
+    return getCustomStatTooltip(index)
+  }
+  return getWeaponStatNames(weaponId)
 }
 
 function getCustomStatDisplayName(id: string): string {

--- a/src/endfield_essence_recognizer/core/layout/dynamic.py
+++ b/src/endfield_essence_recognizer/core/layout/dynamic.py
@@ -248,5 +248,32 @@ class DynamicResolutionProfile(ResolutionProfile):
 
     @property
     def SCROLLBAR_CHECK_POS(self) -> Point:
-        base = _BASE.SCROLLBAR_CHECK_POS
-        return Point(base.x, round(base.y * self._height / _BASE_HEIGHT))
+        """滚动条检测位置，用于判断是否到达底部。
+
+        规律（通过多分辨率实测得出）：
+        - 滚动条位置基于窗口右下角锚定
+        - 右边距 ≈ 高度 × 0.432（16:9 分辨率下）
+        - 下边距 ≈ 高度 × 0.1（16:9 分辨率下）
+
+        实测数据验证（16:9 分辨率）：
+        - 1920×1080 → (1453, 950)：1080×0.432=467, 1080×0.12=130 ✓
+        - 2560×1080 → (2092, 950)：1080×0.432=467, 1080×0.12=130 ✓
+        - 1600×900  → (1210, 810)：900×0.433=390, 900×0.1=90 ✓
+        - 1280×720  → (969, 650)：720×0.432=311, 720×0.1=72 ✓
+
+        注意：1280×1024（5:4 比例）等非标分辨率可能不适用此规律。
+        """
+        # 基于 1080p 实测数据计算缩放系数
+        # 1080p 时：右边距 467，下边距 130
+        base_height = 1080
+        base_right_margin = 467
+        base_bottom_margin = 130
+
+        # 按高度比例动态缩放
+        scale = self._height / base_height
+        right_margin = round(base_right_margin * scale)
+        bottom_margin = round(base_bottom_margin * scale)
+
+        x = self._width - right_margin
+        y = self._height - bottom_margin
+        return Point(x, y)

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import math
 import threading
 
 import numpy as np
@@ -897,6 +898,7 @@ class DraggableScannerEngine(ScannerEngine):
 
             # 执行渐进式拖动翻页
             logger.info("开始渐进式拖动翻页...")
+            row_height = icon_y_list[1] - icon_y_list[0] if len(icon_y_list) > 1 else 0
             progressive_drag_distance, is_last_page = self._progressive_drag(
                 drag_start,
                 drag_end,
@@ -904,6 +906,7 @@ class DraggableScannerEngine(ScannerEngine):
                 stop_event,
                 step=50,  # 每次拖动50像素
                 max_drag=max_drag_distance,
+                row_height=row_height,
             )
 
             if is_last_page:
@@ -1125,6 +1128,7 @@ class DraggableScannerEngine(ScannerEngine):
         stop_event: threading.Event,
         step: int = 50,
         max_drag: int = 800,
+        row_height: int = 0,
     ) -> tuple[int, bool]:
         """
         渐进式拖动，使用 WindowActions 接口执行拖动并检测滚动条。
@@ -1136,6 +1140,7 @@ class DraggableScannerEngine(ScannerEngine):
             stop_event: 停止事件
             step: 每次拖动的像素数
             max_drag: 最大拖动距离
+            row_height: 行高（用于计算是否需要额外滚动到整行位置）
 
         Returns:
             (actual_drag_distance, is_last_page) 实际拖动距离和是否是最后一页
@@ -1167,6 +1172,22 @@ class DraggableScannerEngine(ScannerEngine):
 
         if is_last_page:
             logger.info(f"检测到滚动条到底，已拖动 {actual_distance}px")
+
+            # 检测到滚动条到底时，额外多滚动一整行
+            # 因为检测点可能正好在倒数第二行，需要确保最后一行完全滚出
+            if row_height > 0:
+                scrolled_rows = actual_distance / row_height
+                # 额外滚动一整行，乘以 1.2 系数确保滚动到位
+                extra_drag = int(row_height * 1.2)
+                logger.info(
+                    f"已滚动 {scrolled_rows:.1f} 行，额外滚动一整行 {extra_drag}px 确保到位"
+                )
+                # 等待惯性滚动停止
+                self._window_actions.wait(0.5)
+                # 使用 _correct_overscroll 相同的方式执行额外滚动
+                self._correct_overscroll(drag_start, extra_drag)
+                actual_distance += extra_drag
+                logger.info(f"额外滚动完成，总计拖动 {actual_distance}px")
         else:
             # 拖动完成后再次检测滚动条
             if scrollbar_pos and self._check_scrollbar_at_bottom(scrollbar_pos):
@@ -1195,12 +1216,16 @@ class DraggableScannerEngine(ScannerEngine):
         if max_drag <= 0 or actual_drag <= 0:
             return 0
 
-        # 计算比例并四舍五入为跳过行数
+        # 计算比例，使用 ceil 向上取整确保滚动到位
+        # 例如：2.1、2.5、2.9 都会取整为 3，多滚动一行确保内容完全滚出
+        # 松开鼠标后页面会自动回弹到正确位置
         ratio = actual_drag / max_drag
-        skip_rows = total_rows - round(ratio * total_rows)
+        scrolled_rows = math.ceil(ratio * total_rows)
+        skip_rows = total_rows - scrolled_rows
 
         logger.info(
-            f"计算跳过行数: 比例={ratio:.2f}, 实际滚动={actual_drag}px, 最大={max_drag}px, 跳过={skip_rows}行"
+            f"计算跳过行数: 比例={ratio:.2f}, 实际滚动={actual_drag}px, 最大={max_drag}px, "
+            f"滚动行数={ratio * total_rows:.1f}→{scrolled_rows}, 跳过={skip_rows}行"
         )
 
         return skip_rows

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1219,8 +1219,9 @@ class DraggableScannerEngine(ScannerEngine):
         # 计算比例，使用 ceil 向上取整确保滚动到位
         # 例如：2.1、2.5、2.9 都会取整为 3，多滚动一行确保内容完全滚出
         # 松开鼠标后页面会自动回弹到正确位置
+        # 减 1 抵消 _progressive_drag 中 row_height * 1.2 额外拖拽造成的多算
         ratio = actual_drag / max_drag
-        scrolled_rows = math.ceil(ratio * total_rows)
+        scrolled_rows = max(0, math.ceil(ratio * total_rows) - 1)
         skip_rows = total_rows - scrolled_rows
 
         logger.info(

--- a/src/endfield_essence_recognizer/core/window/windows_utils.py
+++ b/src/endfield_essence_recognizer/core/window/windows_utils.py
@@ -245,16 +245,19 @@ def progressive_drag_on_window(
             current_x = int(screen_start_x + total_dx * progress)
             current_y = int(screen_start_y + total_dy * progress)
 
+            # 移动鼠标并等待游戏处理
             pyautogui.moveTo(current_x, current_y)
-            actual_distance += step_distance
-
             time.sleep(0.05)
 
-            # 调用回调检测
+            # 先检测滚动条，再累加距离
+            # 这样当检测到到底时，当前这一步的距离不会被计入
             if on_step is not None:
                 if on_step(i, current_x, current_y):
                     stopped_early = True
                     break
+
+            # 检测通过后才累加距离
+            actual_distance += step_distance
 
         return int(actual_distance), stopped_early
 


### PR DESCRIPTION
  ## feat: 为方案卡片和武器总览添加武器属性悬浮面板

  - 在基质规划-最优刷取方案的方案卡片中，鼠标悬停武器图标显示三条基质属性
  - 在宝藏基质-武器总览中，鼠标悬停武器图标显示三条基质属性
  - 支持自定义基质的属性悬浮面板显示
  - 新增 `getWeaponTooltipText` 函数统一处理普通武器和自定义基质的悬浮文本
  - 导入 `essencesMap` 以支持 WeaponOverview 中的属性名称查询

  **改动文件：** `WeaponOverview.vue`、`matrix-planner.vue`

  ---

  ## fix(scanner): 修正拖拽翻页末尾行漏扫

  拖拽翻页时，当滚动条检测到底的瞬间，最后一行可能尚未完全滚出可视区域，导致末尾行漏扫。本次修复从三个层面改进：

  1. **滚动条检测位置重写** — `SCROLLBAR_CHECK_POS`
  改为基于窗口右下角锚定，按高度比例动态计算右边距和下边距，替代原有简单缩放，提升多分辨率兼容性
  2. **到底时额外滚动一整行** — 检测到滚动条到底后，额外多滚动一整行（×1.2 系数），确保最后一行完全滚出
  3. **跳行计算改为向上取整** — `_calculate_skip_rows` 由 `round` 改为 `math.ceil`，避免因滚动不足导致漏扫
  4. **距离累加时序调整** — `progressive_drag_on_window` 中先检测滚动条再累加距离，检测到底时当前步距离不计入

  **改动文件：** `dynamic.py`、`engine.py`、`windows_utils.py`