### PR TITLE
fix: 修复基质认领计数、等级同步问题，支持武器名称自动归一化为ID

### DIFF
--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -421,9 +421,7 @@ class ScannerEngine:
             if fixed_entries:
                 for old_id, new_id in fixed_entries:
                     profile_manager.fix_weapon_id(old_id, new_id)
-                    logger.info(
-                        f”已自动修正 profile 中的武器 ID：{old_id} → {new_id}”
-                    )
+                    logger.info(f"已自动修正 profile 中的武器 ID：{old_id} → {new_id}")
 
             # 每组以最高等级作为阈值，并以等于该阈值的数量作为相等跳过名额
             mode = user_setting.same_type_keep_best_mode

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -345,6 +345,23 @@ class ScannerEngine:
 
         return sorted(weapon_ids, key=lambda wid: -get_priority(wid))
 
+    def _resolve_weapon_id(self, weapon_id_or_name: str) -> str:
+        """将武器名称归一化为武器 ID；已是合法 ID 则原样返回。"""
+        if self.ctx.static_game_data.get_weapon(weapon_id_or_name) is not None:
+            return weapon_id_or_name
+        # 按名称查找
+        for w in self.ctx.static_game_data.list_weapons():
+            if w.name == weapon_id_or_name:
+                return w.weapon_id
+        return weapon_id_or_name
+
+    def _weapon_display(self, weapon_id: str) -> str:
+        """返回 "武器名称(武器ID)" 格式，便于日志排查。"""
+        weapon = self.ctx.static_game_data.get_weapon(weapon_id)
+        if weapon:
+            return f"{weapon.name}({weapon_id})"
+        return weapon_id
+
     def _init_weapon_levels_from_profile(self) -> None:
         """从 profile 的宝藏基质配置中初始化已有武器等级。"""
         try:
@@ -354,7 +371,8 @@ class ScannerEngine:
 
             profile = get_profile_manager().get_active_profile()
             for entry in profile.treasure_matrix:
-                self._weapon_essence_levels[entry.weapon_id] = (
+                weapon_id = self._resolve_weapon_id(entry.weapon_id)
+                self._weapon_essence_levels[weapon_id] = (
                     entry.affix1_level,
                     entry.affix2_level,
                     entry.affix3_level,
@@ -374,18 +392,23 @@ class ScannerEngine:
                 get_profile_manager,
             )
 
-            profile = get_profile_manager().get_active_profile()
+            profile_manager = get_profile_manager()
+            profile = profile_manager.get_active_profile()
 
             # 按分组键（武器分组用 weapon_id，基质分组用 stat_key）收集已保存的等级
             group_levels: dict[tuple[str | None, ...] | str, list[tuple]] = {}
+            fixed_entries: list[tuple[str, str]] = []  # (旧 weapon_id, 新 weapon_id)
             for entry in profile.treasure_matrix:
                 levels = (
                     entry.affix1_level,
                     entry.affix2_level,
                     entry.affix3_level,
                 )
-                group_levels.setdefault(entry.weapon_id, []).append(levels)
-                weapon = self.ctx.static_game_data.get_weapon(entry.weapon_id)
+                weapon_id = self._resolve_weapon_id(entry.weapon_id)
+                if weapon_id != entry.weapon_id:
+                    fixed_entries.append((entry.weapon_id, weapon_id))
+                group_levels.setdefault(weapon_id, []).append(levels)
+                weapon = self.ctx.static_game_data.get_weapon(weapon_id)
                 if weapon:
                     stat_key = (
                         weapon.stat1_id,
@@ -393,6 +416,14 @@ class ScannerEngine:
                         weapon.stat3_id,
                     )
                     group_levels.setdefault(stat_key, []).append(levels)
+
+            # 自动修正 profile 中错误的 weapon_id
+            if fixed_entries:
+                for old_id, new_id in fixed_entries:
+                    profile_manager.fix_weapon_id(old_id, new_id)
+                    logger.info(
+                        f”已自动修正 profile 中的武器 ID：{old_id} → {new_id}”
+                    )
 
             # 每组以最高等级作为阈值，并以等于该阈值的数量作为相等跳过名额
             mode = user_setting.same_type_keep_best_mode
@@ -507,7 +538,7 @@ class ScannerEngine:
             if not can_upgrade(weapon_id):
                 blocked_by_downgrade = True
                 logger.debug(
-                    f"武器 {weapon_id} 当前等级 {existing_levels}，"
+                    f"武器 {self._weapon_display(weapon_id)} 当前等级 {existing_levels}，"
                     f"基质等级 {current_levels}，不满足非降级原则，跳过"
                 )
                 continue

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -605,7 +605,9 @@ def _cascade_freed_levels(
         # 认领释放的等级（不增加计数）
         setting._same_type_best_levels[wid] = freed_levels
         _cascade_updated_this_scan.add(wid)
-        logger.debug(f"[级联] 武器 {_weapon_display(wid)} 认领释放的等级 {freed_levels}")
+        logger.debug(
+            f"[级联] 武器 {_weapon_display(wid)} 认领释放的等级 {freed_levels}"
+        )
         break  # 只分配给一把武器
 
 
@@ -714,9 +716,13 @@ def _apply_weapon_group_limit(
                             _display,
                         )
             return evaluation
-        if _claim_by_limit(setting, weapon_id, current_levels, limit, mode, stat_types, _display):
+        if _claim_by_limit(
+            setting, weapon_id, current_levels, limit, mode, stat_types, _display
+        ):
             _claimed_this_scan.add((weapon_id, current_levels))
-            _updated_this_scan.add(weapon_id)  # 认领成功时加入更新集合，确保计数和等级同步到引擎
+            _updated_this_scan.add(
+                weapon_id
+            )  # 认领成功时加入更新集合，确保计数和等级同步到引擎
             return evaluation
 
     # 所有匹配武器都已达上限

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -556,18 +556,24 @@ def _apply_stat_group_limit(
     keep_best: bool,
     mode: KeepBestMode = KeepBestMode.SEQUENTIAL,
     stat_types: list[StatType | None] | None = None,
+    matched_weapon_ids: set[str] | None = None,
 ) -> EvaluationResult:
     """按基质分组（属性组合相同即为同类型）的限制逻辑。
 
     Args:
         mode: 等级比较方式，仅在 keep_best=True 时生效。
         stat_types: 词条类型列表，用于 GREASE 和 WEIGHTED_SUM 模式下动态选择权重表。
+        matched_weapon_ids: 匹配的武器 ID 集合，用于同步更新追踪。
     """
     if keep_best and _claim_as_owned(
         setting, stat_key, current_levels, mode, stat_types
     ):
         return evaluation
     if _claim_by_limit(setting, stat_key, current_levels, limit, mode, stat_types):
+        # 认领成功时，将匹配的武器加入更新集合，确保计数和等级同步到引擎
+        if matched_weapon_ids:
+            for weapon_id in matched_weapon_ids:
+                _updated_this_scan.add(weapon_id)
         return evaluation
     count = setting._same_type_treasure_counts.get(stat_key, 0)
     logger.debug(f"[数量上限] {stat_key} 已达上限 {count}/{limit}，标记为养成材料")
@@ -710,6 +716,7 @@ def _apply_weapon_group_limit(
             return evaluation
         if _claim_by_limit(setting, weapon_id, current_levels, limit, mode, stat_types, _display):
             _claimed_this_scan.add((weapon_id, current_levels))
+            _updated_this_scan.add(weapon_id)  # 认领成功时加入更新集合，确保计数和等级同步到引擎
             return evaluation
 
     # 所有匹配武器都已达上限
@@ -728,10 +735,14 @@ def _apply_same_type_treasure_limit(
     weapon_priority_order: list[str] | None = None,
     static_game_data: StaticGameData | None = None,
 ) -> EvaluationResult:
-    if (
-        evaluation.quality != EssenceQuality.TREASURE
-        or not setting.same_type_treasure_limit_enabled
-    ):
+    if evaluation.quality != EssenceQuality.TREASURE:
+        return evaluation
+
+    # 当限制功能关闭时，仍需将匹配的武器加入更新集合，确保扫描结果同步到引擎
+    if not setting.same_type_treasure_limit_enabled:
+        if matched_weapon_ids:
+            for weapon_id in matched_weapon_ids:
+                _updated_this_scan.add(weapon_id)
         return evaluation
 
     limit = setting.same_type_treasure_limit
@@ -776,6 +787,7 @@ def _apply_same_type_treasure_limit(
         keep_best,
         mode,
         stat_types,
+        matched_weapon_ids,
     )
 
 

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from itertools import accumulate
 
 from loguru import logger
@@ -462,6 +463,7 @@ def _claim_as_owned(
     current_levels: tuple[int, int, int],
     mode: KeepBestMode = KeepBestMode.SEQUENTIAL,
     stat_types: list[StatType | None] | None = None,
+    _weapon_display: Callable[[str], str] = lambda k: k,
 ) -> bool:
     """留大弃小：判断当前基质是否属于该组"已保存"的那一枚（或其升级版）。
 
@@ -486,7 +488,7 @@ def _claim_as_owned(
         if skip > 0:
             setting._same_type_equal_skips[key] = skip - 1
         logger.debug(
-            f"[留大弃小] {key} 基质等级 {current_levels} 优于已保存 {best}，"
+            f"[留大弃小] {_weapon_display(key)} 基质等级 {current_levels} 优于已保存 {best}，"
             f"认领并提升阈值（剩余跳过名额: {skip - 1 if skip > 0 else 0}）"
         )
         return True
@@ -495,17 +497,17 @@ def _claim_as_owned(
         if skip > 0:
             setting._same_type_equal_skips[key] = skip - 1
             logger.debug(
-                f"[留大弃小] {key} 基质等级 {current_levels} 等于已保存 {best}，"
+                f"[留大弃小] {_weapon_display(key)} 基质等级 {current_levels} 等于已保存 {best}，"
                 f"认领（剩余跳过名额: {skip - 1}）"
             )
             return True
         logger.debug(
-            f"[留大弃小] {key} 基质等级 {current_levels} 等于已保存 {best}，"
+            f"[留大弃小] {_weapon_display(key)} 基质等级 {current_levels} 等于已保存 {best}，"
             f"但跳过名额已用尽，不认领"
         )
     else:
         logger.debug(
-            f"[留大弃小] {key} 基质等级 {current_levels} 劣于已保存 {best}，不认领"
+            f"[留大弃小] {_weapon_display(key)} 基质等级 {current_levels} 劣于已保存 {best}，不认领"
         )
     return False
 
@@ -517,6 +519,7 @@ def _claim_by_limit(
     limit: int,
     mode: KeepBestMode = KeepBestMode.SEQUENTIAL,
     stat_types: list[StatType | None] | None = None,
+    _weapon_display: Callable[[str], str] = lambda k: k,
 ) -> bool:
     """按数量上限认领当前基质：未达上限则保留并计数，同时维护最佳等级。
 
@@ -527,14 +530,19 @@ def _claim_by_limit(
     count = setting._same_type_treasure_counts.get(key, 0)
     if count >= limit:
         return False
-    setting._same_type_treasure_counts[key] = count + 1
     best = setting._same_type_best_levels.get(key)
+    if best is not None and _level_cmp(current_levels, best, mode, stat_types) < 0:
+        logger.debug(
+            f"[数量上限] {_weapon_display(key)} 基质等级 {current_levels} 劣于已保存 {best}，不认领"
+        )
+        return False
+    setting._same_type_treasure_counts[key] = count + 1
     if best is None or _level_cmp(current_levels, best, mode, stat_types) > 0:
         setting._same_type_best_levels[key] = current_levels
         if isinstance(key, str) and key.startswith("wpn_"):
             _updated_this_scan.add(key)
     logger.debug(
-        f"[数量上限] {key} 认领基质等级 {current_levels}，当前计数 {count + 1}/{limit}"
+        f"[数量上限] {_weapon_display(key)} 认领基质等级 {current_levels}，当前计数 {count + 1}/{limit}"
     )
     return True
 
@@ -573,6 +581,7 @@ def _cascade_freed_levels(
     limit: int,
     mode: KeepBestMode,
     stat_types: list[StatType | None] | None,
+    _weapon_display: Callable[[str], str] = lambda k: k,
 ) -> None:
     """级联：将一把武器升级后释放的旧等级分配给剩余武器。
 
@@ -590,7 +599,7 @@ def _cascade_freed_levels(
         # 认领释放的等级（不增加计数）
         setting._same_type_best_levels[wid] = freed_levels
         _cascade_updated_this_scan.add(wid)
-        logger.debug(f"[级联] 武器 {wid} 认领释放的等级 {freed_levels}")
+        logger.debug(f"[级联] 武器 {_weapon_display(wid)} 认领释放的等级 {freed_levels}")
         break  # 只分配给一把武器
 
 
@@ -605,6 +614,7 @@ def _apply_weapon_group_limit(
     stat_types: list[StatType | None] | None = None,
     weapon_essence_levels: dict[str, tuple[int, int, int]] | None = None,
     weapon_priority_order: list[str] | None = None,
+    static_game_data: StaticGameData | None = None,
 ) -> EvaluationResult:
     """按武器分组（每把武器独立计数）的限制逻辑。
 
@@ -619,6 +629,14 @@ def _apply_weapon_group_limit(
     else:
         weapon_ids = sorted(matched_weapon_ids)
 
+    # 武器名称显示工具：输出 "武器名称(武器ID)" 格式
+    def _display(wid: str) -> str:
+        if static_game_data:
+            weapon = static_game_data.get_weapon(wid)
+            if weapon:
+                return f"{weapon.name}({wid})"
+        return wid
+
     # 过滤掉基质等级不满足非降级原则的武器
     if weapon_essence_levels and setting.same_type_non_downgrade_filter:
         upgradeable_ids = []
@@ -626,7 +644,7 @@ def _apply_weapon_group_limit(
             existing = weapon_essence_levels.get(wid)
             if existing is None:
                 upgradeable_ids.append(wid)
-                logger.debug(f"[非降级] 武器 {wid} 无已保存基质，通过")
+                logger.debug(f"[非降级] 武器 {_display(wid)} 无已保存基质，通过")
             elif (
                 current_levels[0] >= existing[0]
                 and current_levels[1] >= existing[1]
@@ -634,7 +652,7 @@ def _apply_weapon_group_limit(
             ):
                 upgradeable_ids.append(wid)
                 logger.debug(
-                    f"[非降级] 武器 {wid} 已保存等级 {existing}，"
+                    f"[非降级] 武器 {_display(wid)} 已保存等级 {existing}，"
                     f"基质等级 {current_levels}，满足非降级原则，通过"
                 )
             else:
@@ -646,7 +664,7 @@ def _apply_weapon_group_limit(
                     if current_levels[i] < existing[i]
                 ]
                 logger.debug(
-                    f"[非降级] 武器 {wid} 已保存等级 {existing}，"
+                    f"[非降级] 武器 {_display(wid)} 已保存等级 {existing}，"
                     f"基质等级 {current_levels}，"
                     f"不满足非降级原则（{', '.join(failed)}），过滤"
                 )
@@ -671,7 +689,7 @@ def _apply_weapon_group_limit(
     for i, weapon_id in enumerate(weapon_ids):
         old_best = setting._same_type_best_levels.get(weapon_id)
         if keep_best and _claim_as_owned(
-            setting, weapon_id, current_levels, mode, stat_types
+            setting, weapon_id, current_levels, mode, stat_types, _display
         ):
             # 留大弃小认领成功，检查是否是升级（而非相等跳过）
             if old_best is not None and old_best != current_levels:
@@ -687,15 +705,16 @@ def _apply_weapon_group_limit(
                             limit,
                             mode,
                             stat_types,
+                            _display,
                         )
             return evaluation
-        if _claim_by_limit(setting, weapon_id, current_levels, limit, mode, stat_types):
+        if _claim_by_limit(setting, weapon_id, current_levels, limit, mode, stat_types, _display):
             _claimed_this_scan.add((weapon_id, current_levels))
             return evaluation
 
     # 所有匹配武器都已达上限
     logger.debug(
-        f"[数量上限] 所有可选武器 {weapon_ids} 均已达上限 {limit}，标记为养成材料"
+        f"[数量上限] 所有可选武器 {', '.join(_display(w) for w in weapon_ids)} 均已达上限 {limit}，标记为养成材料"
     )
     return _make_trash_by_limit(evaluation, limit, limit)
 
@@ -707,6 +726,7 @@ def _apply_same_type_treasure_limit(
     matched_weapon_ids: set[str] | None = None,
     weapon_essence_levels: dict[str, tuple[int, int, int]] | None = None,
     weapon_priority_order: list[str] | None = None,
+    static_game_data: StaticGameData | None = None,
 ) -> EvaluationResult:
     if (
         evaluation.quality != EssenceQuality.TREASURE
@@ -742,6 +762,7 @@ def _apply_same_type_treasure_limit(
             stat_types,
             weapon_essence_levels,
             weapon_priority_order,
+            static_game_data,
         )
 
     # 默认按基质分组（包括自定义基质匹配和无匹配武器的情况）
@@ -809,6 +830,7 @@ def evaluate_essence(
                         is_high_level=True,
                     ),
                     weapon_essence_levels=weapon_essence_levels,
+                    static_game_data=static_game_data,
                 )
             else:
                 return EvaluationResult(
@@ -838,6 +860,7 @@ def evaluate_essence(
                     is_high_level=is_high_level_treasure,
                 ),
                 weapon_essence_levels=weapon_essence_levels,
+                static_game_data=static_game_data,
             )
 
     # 按语义类型构建武器匹配三元组（每种类型取第一个出现的 stat）
@@ -871,6 +894,7 @@ def evaluate_essence(
                     is_high_level=True,
                 ),
                 weapon_essence_levels=weapon_essence_levels,
+                static_game_data=static_game_data,
             )
         else:
             return EvaluationResult(
@@ -916,6 +940,7 @@ def evaluate_essence(
             matched_weapon_ids=non_trash_weapon_ids,
             weapon_essence_levels=weapon_essence_levels,
             weapon_priority_order=weapon_priority_order,
+            static_game_data=static_game_data,
         )
     else:
         # 所有匹配到的武器都在 trash_weapon_ids 中
@@ -940,6 +965,7 @@ def evaluate_essence(
                 matched_weapon_ids=matched_weapon_ids,
                 weapon_essence_levels=weapon_essence_levels,
                 weapon_priority_order=weapon_priority_order,
+                static_game_data=static_game_data,
             )
         else:
             return EvaluationResult(

--- a/src/endfield_essence_recognizer/services/profile_manager.py
+++ b/src/endfield_essence_recognizer/services/profile_manager.py
@@ -426,6 +426,27 @@ class ProfileManager:
             self._commit_collection_unlocked(collection)
             return profile.model_copy(deep=True)
 
+    def fix_weapon_id(self, old_weapon_id: str, new_weapon_id: str) -> None:
+        """修正 profile 中错误的武器 ID（如名称 → 正确 ID）。
+
+        同时迁移 weapon_priorities 中的对应条目。
+        """
+        with self._lock:
+            collection = self._collection.model_copy(deep=True)
+            profile = collection.get_active()
+            changed = False
+            for entry in profile.treasure_matrix:
+                if entry.weapon_id == old_weapon_id:
+                    entry.weapon_id = new_weapon_id
+                    changed = True
+            if old_weapon_id in profile.weapon_priorities:
+                profile.weapon_priorities[new_weapon_id] = (
+                    profile.weapon_priorities.pop(old_weapon_id)
+                )
+                changed = True
+            if changed:
+                self._commit_collection_unlocked(collection)
+
     def update_weapon_overview_filters(self, filters: dict[str, bool]) -> ProfileData:
         """更新激活账号的武器总览过滤器配置。
 

--- a/tests/unit/core/scanner/test_engine.py
+++ b/tests/unit/core/scanner/test_engine.py
@@ -388,7 +388,9 @@ def test_exact_level_skip_isolated_by_level(
         user_setting_manager=mock_user_setting_manager,
         profile=mock_profile,
     )
-    weapon = SimpleNamespace(stat1_id="attr", stat2_id="secondary", stat3_id="skill")
+    weapon = SimpleNamespace(
+        name="TestWeapon", stat1_id="attr", stat2_id="secondary", stat3_id="skill"
+    )
     mock_scanner_context.static_game_data.get_weapon.return_value = weapon
     engine._sort_weapons_by_priority = lambda _ids: ["w1", "w2"]
 
@@ -412,7 +414,9 @@ def test_downgrade_blocked_essence_is_not_fallback_counted(
         user_setting_manager=mock_user_setting_manager,
         profile=mock_profile,
     )
-    weapon = SimpleNamespace(stat1_id="attr", stat2_id="secondary", stat3_id="skill")
+    weapon = SimpleNamespace(
+        name="TestWeapon", stat1_id="attr", stat2_id="secondary", stat3_id="skill"
+    )
     mock_scanner_context.static_game_data.get_weapon.return_value = weapon
     engine._sort_weapons_by_priority = lambda _ids: ["w1"]
     engine._weapon_essence_levels = {"w1": (3, 3, 2)}


### PR DESCRIPTION
  ### 1. 武器名称自动归一化为 ID

  - 新增 `_resolve_weapon_id` 方法，将武器名称自动转换为武器 ID，兼容 profile 中存储名称而非 ID 的历史数据
  - 新增 `ProfileManager.fix_weapon_id` 方法，自动修正 profile 中错误的 weapon_id，并同步迁移 `weapon_priorities`
  - 日志输出统一使用"武器名称(武器ID)"格式，便于排查

  ### 2. 修复基质认领后计数/等级未同步更新到引擎

  - `_apply_stat_group_limit`、`_apply_weapon_group_limit`、`_apply_same_type_treasure_limit` 中，基质被成功认领时将匹配的武器 ID 加入 `_updated_this_scan` 集合，确保认领结果正确同步到扫描引擎
  - 即使限制功能关闭，仍将匹配武器加入更新集合以保持数据一致性

  ### 3. 认领逻辑优化

  - `_claim_by_limit` 新增非降级检查：等级劣于已保存最佳等级的基质不再被认领，避免低等级基质占用数量上限

  ## 涉及文件

  - `core/scanner/engine.py` — 武器 ID 解析、profile 自动修正、日志显示
  - `core/scanner/evaluate.py` — 认领同步修复、非降级检查、日志优化
  - `services/profile_manager.py` — 新增 `fix_weapon_id` 方法