### PR TITLE
fix(evaluate): 修复 ONLY 模式下非标基质高等级判定逻辑

### DIFF
--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -199,31 +199,39 @@ def _evaluate_high_level_treasure(
             original_slot_matches.append(level >= threshold)
 
     if mode == TreasureMatchMode.ONLY:
-        eval_matches = [
-            m
-            for m, st in zip(original_slot_matches, stat_types, strict=True)
-            if st is not None
-            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+        # ONLY 模式：按类型分组，每种勾选的类型只要至少有一个词条达标即可
+        type_has_match: dict[str, bool] = {}
+        type_matched_indexes: dict[str, list[int]] = {}
+        for i, (m, st) in enumerate(
+            zip(original_slot_matches, stat_types, strict=True)
+        ):
+            if st is None:
+                continue
+            slot = _TYPE_TO_SLOT.get(st, "")
+            if not only_flags_by_type.get(slot, False):
+                continue
+            if slot not in type_has_match:
+                type_has_match[slot] = False
+                type_matched_indexes[slot] = []
+            if m:
+                type_has_match[slot] = True
+                type_matched_indexes[slot].append(i)
+
+        eval_matches = list(type_has_match.values())
+        matched_indexes = [
+            idx
+            for indexes in type_matched_indexes.values()
+            if indexes  # 只包含至少有一个达标词条的类型
+            for idx in indexes
         ]
     else:
         eval_matches = original_slot_matches
-
-    if mode == TreasureMatchMode.ONLY:
-        matched_indexes = [
-            i
-            for i, (m, st) in enumerate(
-                zip(original_slot_matches, stat_types, strict=True)
+        if mode == TreasureMatchMode.ANY:
+            matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
+        else:
+            matched_indexes = (
+                list(range(len(STAT_SLOTS))) if all(original_slot_matches) else []
             )
-            if m
-            and st is not None
-            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
-        ]
-    elif mode == TreasureMatchMode.ANY:
-        matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
-    else:
-        matched_indexes = (
-            list(range(len(STAT_SLOTS))) if all(original_slot_matches) else []
-        )
 
     if not _matches_by_mode(eval_matches, len(eval_matches), mode):
         return False, ""
@@ -301,31 +309,39 @@ def _evaluate_non_five_star_high_level(
             original_slot_matches.append(level >= threshold)
 
     if mode == TreasureMatchMode.ONLY:
-        eval_matches = [
-            m
-            for m, st in zip(original_slot_matches, stat_types, strict=True)
-            if st is not None
-            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
+        # ONLY 模式：按类型分组，每种勾选的类型只要至少有一个词条达标即可
+        type_has_match: dict[str, bool] = {}
+        type_matched_indexes: dict[str, list[int]] = {}
+        for i, (m, st) in enumerate(
+            zip(original_slot_matches, stat_types, strict=True)
+        ):
+            if st is None:
+                continue
+            slot = _TYPE_TO_SLOT.get(st, "")
+            if not only_flags_by_type.get(slot, False):
+                continue
+            if slot not in type_has_match:
+                type_has_match[slot] = False
+                type_matched_indexes[slot] = []
+            if m:
+                type_has_match[slot] = True
+                type_matched_indexes[slot].append(i)
+
+        eval_matches = list(type_has_match.values())
+        matched_indexes = [
+            idx
+            for indexes in type_matched_indexes.values()
+            if indexes  # 只包含至少有一个达标词条的类型
+            for idx in indexes
         ]
     else:
         eval_matches = original_slot_matches
-
-    if mode == TreasureMatchMode.ONLY:
-        matched_indexes = [
-            i
-            for i, (m, st) in enumerate(
-                zip(original_slot_matches, stat_types, strict=True)
+        if mode == TreasureMatchMode.ANY:
+            matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
+        else:
+            matched_indexes = (
+                list(range(len(STAT_SLOTS))) if all(original_slot_matches) else []
             )
-            if m
-            and st is not None
-            and only_flags_by_type.get(_TYPE_TO_SLOT.get(st, ""), False)
-        ]
-    elif mode == TreasureMatchMode.ANY:
-        matched_indexes = [i for i, m in enumerate(original_slot_matches) if m]
-    else:
-        matched_indexes = (
-            list(range(len(STAT_SLOTS))) if all(original_slot_matches) else []
-        )
 
     if not _matches_by_mode(eval_matches, len(eval_matches), mode):
         return False, ""


### PR DESCRIPTION
#181有一个神秘的分割符 \u200c 故重新提交分支

  修复高等级基质属性词条判定中 ONLY 模式对非标基质（如三个同类型词条）的处理逻辑。

  修改前：ONLY 模式要求所有匹配类型的词条都达到阈值，导致非标基质（如三个技能属性 1/1/3）
  即使有高等级词条（3）也会因低等级词条（1）被判定为非高等级。

  修改后：ONLY 模式按类型分组，每种勾选的类型只要至少有一个词条达标即可。

  修改范围：
  - 无瑕基质高等级判定（_evaluate_high_level_treasure）
  - 非无瑕基质高等级判定（_evaluate_non_five_star_high_level）