### PR TITLE
feat: 新增"如果缺少词条,则弃用"的选项

### DIFF
--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -677,6 +677,7 @@
                 <v-radio label="解锁且取消弃用" value="unlock_and_undeprecate"></v-radio>
                 <v-radio disabled label="如果没有上锁，则弃用" value="deprecate_if_not_locked" />
                 <v-radio label="如果没有弃用，则上锁" value="lock_if_not_deprecated" />
+                <v-radio disabled label="如果缺少词条，则弃用" value="deprecate_if_missing_stats" />
               </v-radio-group>
             </v-col>
             <v-col cols="12" md="6">

--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -690,6 +690,7 @@
                 <v-radio label="解锁且取消弃用" value="unlock_and_undeprecate" />
                 <v-radio label="如果没有上锁，则弃用" value="deprecate_if_not_locked" />
                 <v-radio label="如果没有弃用，则上锁" value="lock_if_not_deprecated" />
+                <v-radio label="如果缺少词条，则弃用" value="deprecate_if_missing_stats" />
               </v-radio-group>
             </v-col>
           </v-row>

--- a/src/endfield_essence_recognizer/core/scanner/action_logic.py
+++ b/src/endfield_essence_recognizer/core/scanner/action_logic.py
@@ -10,7 +10,26 @@ from endfield_essence_recognizer.core.scanner.models import (
     EssenceQuality,
     EvaluationResult,
 )
+from endfield_essence_recognizer.game_data.models.v2 import StatType
 from endfield_essence_recognizer.schemas.user_setting import Action, UserSetting
+
+
+def _is_missing_stats(data: EssenceData) -> bool:
+    """检查基质是否缺少任意一项词条（基础属性、附加属性、技能属性）。"""
+    type_to_stat: dict[StatType, str | None] = {}
+    for stat_id, stat_type in zip(data.stats, data.stat_types, strict=True):
+        if (
+            stat_type is not None
+            and stat_id is not None
+            and stat_type not in type_to_stat
+        ):
+            type_to_stat[stat_type] = stat_id
+
+    has_attribute = StatType.ATTRIBUTE in type_to_stat
+    has_secondary = StatType.SECONDARY in type_to_stat
+    has_skill = StatType.SKILL in type_to_stat
+
+    return not (has_attribute and has_secondary and has_skill)
 
 
 class ActionType(Enum):
@@ -92,6 +111,7 @@ def decide_actions(
     # --- Abandon Logic ---
     should_abandon = False
     should_unabandon = False
+    is_missing_stats_action = False
 
     if target_action == Action.DEPRECATE:
         should_abandon = True
@@ -102,14 +122,25 @@ def decide_actions(
         and data.lock_label == LockStatusLabel.NOT_LOCKED
     ):
         should_abandon = True
+    elif target_action == Action.DEPRECATE_IF_MISSING_STATS and _is_missing_stats(data):
+        should_abandon = True
+        is_missing_stats_action = True
 
     if data.abandon_label == AbandonStatusLabel.NOT_ABANDONED and should_abandon:
-        actions.append(
-            ScannerAction(
-                type=ActionType.CLICK_ABANDON,
-                log_message="给你自动标记为弃用了！(￣︶￣)>",
+        if is_missing_stats_action:
+            actions.append(
+                ScannerAction(
+                    type=ActionType.CLICK_ABANDON,
+                    log_message="因为缺少词条，给你自动标记为弃用了！(￣︶￣)>",
+                )
             )
-        )
+        else:
+            actions.append(
+                ScannerAction(
+                    type=ActionType.CLICK_ABANDON,
+                    log_message="给你自动标记为弃用了！(￣︶￣)>",
+                )
+            )
     elif data.abandon_label == AbandonStatusLabel.ABANDONED and should_unabandon:
         actions.append(
             ScannerAction(

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -784,7 +784,7 @@ def _apply_same_type_treasure_limit(
         setting.same_type_group_mode == SameTypeGroupMode.BY_WEAPON
         and matched_weapon_ids
     ):
-        return _apply_weapon_group_limit(
+        result = _apply_weapon_group_limit(
             setting,
             evaluation,
             matched_weapon_ids,
@@ -797,10 +797,11 @@ def _apply_same_type_treasure_limit(
             weapon_priority_order,
             static_game_data,
         )
+        return result
 
     # 默认按基质分组（包括自定义基质匹配和无匹配武器的情况）
     stat_key = tuple(data.stats)
-    return _apply_stat_group_limit(
+    result = _apply_stat_group_limit(
         setting,
         evaluation,
         stat_key,
@@ -811,6 +812,7 @@ def _apply_same_type_treasure_limit(
         stat_types,
         matched_weapon_ids,
     )
+    return result
 
 
 def evaluate_essence(

--- a/src/endfield_essence_recognizer/schemas/user_setting.py
+++ b/src/endfield_essence_recognizer/schemas/user_setting.py
@@ -23,6 +23,7 @@ class Action(StrEnum):
     UNLOCK_AND_UNDEPRECATE = "unlock_and_undeprecate"
     DEPRECATE_IF_NOT_LOCKED = "deprecate_if_not_locked"
     LOCK_IF_NOT_DEPRECATED = "lock_if_not_deprecated"
+    DEPRECATE_IF_MISSING_STATS = "deprecate_if_missing_stats"
 
 
 class NonFiveStarBehavior(StrEnum):


### PR DESCRIPTION
  - 在设置页面添加"如果缺少词条，则弃用"的单选按钮
  - 新增 DEPRECATE_IF_MISSING_STATS 枚举值
  - 实现 _is_missing_stats 函数检查基质是否缺少基础属性、附加属性或技能属性
  - 当基质缺少任意一项词条时自动标记为弃用，并显示特定提示信息
  - 重构 _apply_same_type_treasure_limit 函数中的 return 语句，提升代码可读性