### PR TITLE
fix: 关闭同类型宝藏限制后同步扫描结果到 profiles.json

### DIFF
--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -763,8 +763,26 @@ def _apply_same_type_treasure_limit(
     # 当限制功能关闭时，仍需将匹配的武器加入更新集合，确保扫描结果同步到引擎
     if not setting.same_type_treasure_limit_enabled:
         if matched_weapon_ids:
+            current_levels = (
+                data.levels[0] or 1,
+                data.levels[1] or 1,
+                data.levels[2] or 1,
+            )
+            stat_types = data.stat_types
+            mode = setting.same_type_keep_best_mode
             for weapon_id in matched_weapon_ids:
                 _updated_this_scan.add(weapon_id)
+                # 保留同武器中等级最高的基质，后续写回宝藏基质配置时以最高等级为准
+                best = setting._same_type_best_levels.get(weapon_id)
+                if (
+                    best is None
+                    or _level_cmp(current_levels, best, mode, stat_types) > 0
+                ):
+                    setting._same_type_best_levels[weapon_id] = current_levels
+                # 累计每把武器认领的基质数量，用于最终统计输出
+                setting._same_type_treasure_counts[weapon_id] = (
+                    setting._same_type_treasure_counts.get(weapon_id, 0) + 1
+                )
         return evaluation
 
     limit = setting.same_type_treasure_limit

--- a/tests/unit/core/scanner/test_evaluate.py
+++ b/tests/unit/core/scanner/test_evaluate.py
@@ -379,6 +379,70 @@ def test_evaluate_same_type_treasure_limit_marks_later_items_as_trash(
     assert "达到设置上限" in second.log_message
 
 
+def test_evaluate_same_type_treasure_limit_disabled_updates_best_levels(
+    mock_static_game_data, default_settings, default_essence_data
+):
+    """限制关闭时，仍会更新 _same_type_best_levels 和 _same_type_treasure_counts。"""
+    default_settings.same_type_treasure_limit_enabled = False
+    default_settings.treasure_essence_stats = [
+        EssenceStats(attribute="A", secondary="B", skill="C")
+    ]
+
+    mock_static_game_data.find_weapons_by_stats.return_value = ["wpn_A", "wpn_B"]
+    weapon_mock = MagicMock()
+    weapon_mock.weapon_id = "wpn_A"
+    weapon_mock.name = "WeaponA"
+    weapon_mock.rarity = 6
+    weapon_mock.weapon_type = 1
+    mock_static_game_data.get_weapon.return_value = weapon_mock
+
+    result = evaluate_essence(
+        default_essence_data, default_settings, mock_static_game_data
+    )
+
+    assert result.quality == EssenceQuality.TREASURE
+    # _same_type_best_levels 应包含两把武器，等级均为 (1, 1, 1)（levels=[0,0,0] 或 1）
+    assert "wpn_A" in default_settings._same_type_best_levels
+    assert "wpn_B" in default_settings._same_type_best_levels
+    assert default_settings._same_type_best_levels["wpn_A"] == (1, 1, 1)
+    assert default_settings._same_type_best_levels["wpn_B"] == (1, 1, 1)
+    # _same_type_treasure_counts 应累计 1
+    assert default_settings._same_type_treasure_counts["wpn_A"] == 1
+    assert default_settings._same_type_treasure_counts["wpn_B"] == 1
+
+
+def test_evaluate_same_type_treasure_limit_disabled_keeps_highest_level(
+    mock_static_game_data, default_settings, default_essence_data
+):
+    """限制关闭时，同一武器的多次扫描应保留最高等级。"""
+    default_settings.same_type_treasure_limit_enabled = False
+    mock_static_game_data.find_weapons_by_stats.return_value = ["wpn_A"]
+    weapon_mock = MagicMock()
+    weapon_mock.weapon_id = "wpn_A"
+    weapon_mock.name = "WeaponA"
+    weapon_mock.rarity = 6
+    weapon_mock.weapon_type = 1
+    mock_static_game_data.get_weapon.return_value = weapon_mock
+
+    # 第一次扫描：低等级
+    default_essence_data.levels = [1, 1, 1]
+    evaluate_essence(default_essence_data, default_settings, mock_static_game_data)
+    assert default_settings._same_type_best_levels["wpn_A"] == (1, 1, 1)
+
+    # 第二次扫描：更高等级
+    default_essence_data.levels = [3, 2, 1]
+    evaluate_essence(default_essence_data, default_settings, mock_static_game_data)
+    assert default_settings._same_type_best_levels["wpn_A"] == (3, 2, 1)
+
+    # 第三次扫描：更低等级，不应覆盖
+    default_essence_data.levels = [2, 1, 1]
+    evaluate_essence(default_essence_data, default_settings, mock_static_game_data)
+    assert default_settings._same_type_best_levels["wpn_A"] == (3, 2, 1)
+
+    # 计数应累计 3 次
+    assert default_settings._same_type_treasure_counts["wpn_A"] == 3
+
+
 def test_evaluate_non_five_star_skip(
     mock_static_game_data, default_settings, default_essence_data
 ):


### PR DESCRIPTION
## 修复内容

关闭「同类型宝藏限制」功能（`same_type_treasure_limit_enabled` 设为 `false`）后，扫描基质不会更新 `profiles.json` 中的宝藏基质配置。

关联 Issue: [#195](https://github.com/Logical-Byte/endfield-essence-recognizer/issues/195)

### 根因

`_apply_same_type_treasure_limit()` 在限制关闭时直接返回，只将武器 ID 加入 `_updated_this_scan`，但未同步等级数据到 `_same_type_best_levels`。引擎的同步循环读取到 `None` 等级，导致 `_weapon_essence_levels` 为空，`_on_scan_complete` 发现 0 把武器后不会调用 `_sync_to_treasure_matrix()`，最终 `profiles.json` 未更新。

### 修改

- 限制关闭时也更新 `_same_type_best_levels[weapon_id]`，使用 `_level_cmp` 对比保留最高等级
- 同时累计 `_same_type_treasure_counts[weapon_id]`

### 测试

新增两个测试用例验证：
1. 限制关闭时 `_same_type_best_levels` 和 `_same_type_treasure_counts` 正确更新
2. 同一武器多次扫描时保留最高等级

```
335 passed, 1 skipped
```