### PR TITLE
feat(weapon-detail): 新增「查看最优刷取方案」按钮及基质默认图标

### DIFF
--- a/frontend/src/components/CustomStatIcon.vue
+++ b/frontend/src/components/CustomStatIcon.vue
@@ -46,10 +46,10 @@ watch([() => props.name, nameRef], () => {
 // 底板图片路径
 const essenceBgSrc = computed(() => matrixIcons.value.essenceBg)
 
-// 技能属性图标路径
+// 技能属性图标路径；属性缺失或未匹配时兜底显示默认基质图标
 const skillIconSrc = computed(() => {
-  if (!props.skillStatId) return null
-  return matrixIcons.value.skills[props.skillStatId] || null
+  if (!props.skillStatId) return matrixIcons.value.defaultIcon || null
+  return matrixIcons.value.skills[props.skillStatId] || matrixIcons.value.defaultIcon || null
 })
 
 // 技能图标 alt 文本：用词条的中文名，英文缩写对读屏软件没有意义

--- a/frontend/src/components/WeaponDetailDialog.vue
+++ b/frontend/src/components/WeaponDetailDialog.vue
@@ -17,9 +17,10 @@
           <v-text-field
             v-if="isCustomEntry(weaponId) || isNewCustom"
             v-model="customEntryName"
+            class="custom-name-field"
             density="compact"
             hide-details
-            placeholder="自定义基质名称"
+            placeholder="自定义基质名称(点我进行修改)"
             variant="underlined"
           />
           <template v-else>
@@ -99,6 +100,19 @@
             </v-col>
           </v-row>
         </div>
+
+        <!-- 跳转基质规划：查看该基质的刷取方案 -->
+        <v-btn
+          v-if="!isNewCustom"
+          class="mb-4"
+          color="primary"
+          prepend-icon="mdi-map-search"
+          size="small"
+          variant="tonal"
+          @click="navigateToPlanner"
+        >
+          查看最优刷取方案
+        </v-btn>
 
         <!-- 基质等级 -->
         <div class="mb-4 detail-level-outer">
@@ -347,6 +361,7 @@
 
 <script lang="ts" setup>
 import { computed, onUnmounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import CustomStatIcon from '@/components/CustomStatIcon.vue'
 import ItemIcon from '@/components/ItemIcon.vue'
 import { useCustomStats } from '@/composables/useCustomStats'
@@ -364,6 +379,23 @@ const dialogOpen = computed({
     if (!open) weaponId.value = null
   },
 })
+
+const router = useRouter()
+
+/**
+ * 跳转到基质规划页面，在武器预设中选中当前基质并计算最优刷取方案。
+ * 不使用预刻券模式保持关闭（不传 noPrecraft 参数）。
+ */
+function navigateToPlanner() {
+  const id = weaponId.value
+  if (!id || id === '__new_custom__') return
+  router.push({
+    name: 'matrix-planner',
+    query: { clear: 'true', weapon: id },
+  })
+  // 滚动到页面顶部
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
 
 const { weaponsMap, essencesMap } = useStaticData()
 const { treasureMatrix, updateTreasureMatrix, updateWeaponPriority } = useProfiles()
@@ -922,6 +954,11 @@ async function swapMatrix(weaponAId: string, weaponBId: string) {
   height: 3rem !important;
   min-width: 3rem !important;
   min-height: 3rem !important;
+}
+
+// 自定义基质名称输入框：字号与内置武器名（v-card-title 默认 1.25rem）保持一致
+.custom-name-field :deep(.v-field__input) {
+  font-size: 1.25em;
 }
 
 .weapon-icon-same {

--- a/frontend/src/components/WeaponOverview.vue
+++ b/frontend/src/components/WeaponOverview.vue
@@ -72,7 +72,10 @@
         <!-- 自定义基质区段 -->
         <template v-if="showCustomSection">
           <div class="d-flex align-center mb-1 mt-3">
-            <img v-if="essenceBgSrc" alt="" class="essence-icon-small me-2" :src="essenceBgSrc" />
+            <span class="essence-icon-stack me-2">
+              <img v-if="essenceBgSrc" alt="" :src="essenceBgSrc" />
+              <img v-if="defaultIconSrc" alt="" :src="defaultIconSrc" />
+            </span>
             <h4>自定义基质</h4>
           </div>
           <div class="weapon-overview-grid">
@@ -348,19 +351,22 @@ watch(
 
 // 底板图片路径
 const essenceBgSrc = computed(() => matrixIcons.value.essenceBg)
+// 默认基质图标路径（叠加在底板上）
+const defaultIconSrc = computed(() => matrixIcons.value.defaultIcon)
 
 // --- 武器卡片辅助函数 ---
 
-/** 获取武器的技能属性图标 URL */
+/** 获取武器的技能属性图标 URL；属性缺失或未匹配时兜底返回默认基质图标 */
 function getWeaponSkillIcon(weaponId: string): string | null {
+  const fallback = matrixIcons.value.defaultIcon || null
   const found = findCustomStat(weaponId, customStats.value)
   if (found) {
-    if (!found.stat.skill) return null
-    return matrixIcons.value.skills[found.stat.skill] || null
+    if (!found.stat.skill) return fallback
+    return matrixIcons.value.skills[found.stat.skill] || fallback
   }
   const weapon = weaponsMap.value.get(weaponId)
-  if (!weapon?.skillStatId) return null
-  return matrixIcons.value.skills[weapon.skillStatId] || null
+  if (!weapon?.skillStatId) return fallback
+  return matrixIcons.value.skills[weapon.skillStatId] || fallback
 }
 
 // 武器详情弹窗（null=关闭，string=打开编辑该武器）

--- a/frontend/src/pages/matrix-planner.vue
+++ b/frontend/src/pages/matrix-planner.vue
@@ -496,12 +496,10 @@
                 v-if="selectedRarities.includes('custom') && customMatrixEntries.length > 0"
               >
                 <div class="d-flex align-center mb-2 mt-4">
-                  <img
-                    v-if="essenceBgSrc"
-                    alt=""
-                    class="essence-icon-small me-2"
-                    :src="essenceBgSrc"
-                  />
+                  <span class="essence-icon-stack me-2">
+                    <img v-if="essenceBgSrc" alt="" :src="essenceBgSrc" />
+                    <img v-if="defaultIconSrc" alt="" :src="defaultIconSrc" />
+                  </span>
                   <h4>自定义基质</h4>
                 </div>
                 <div class="weapon-grid">
@@ -638,6 +636,8 @@ const { customStats, customMatrixEntries, fetchCustomStats } = useCustomStats()
 
 // 底板图片路径
 const essenceBgSrc = computed(() => matrixIcons.value.essenceBg)
+// 默认基质图标路径（叠加在底板上）
+const defaultIconSrc = computed(() => matrixIcons.value.defaultIcon)
 // 页面渲染中会频繁判断"是否已有基质"，用 Set 避免对 treasureMatrix 反复线性扫描。
 const obtainedWeaponIds = computed(
   () => new Set(treasureMatrix.value.map((entry) => entry.weapon_id)),
@@ -1002,6 +1002,33 @@ function getSelectedWeaponMatchCount(choice: BattleChoice): number {
 }
 
 /**
+ * 根据 URL 参数选中武器并加入需求列表。
+ *
+ * 内置武器直接按 weaponId 添加；自定义基质需要先从配置中解析
+ * 出属性组合（fetchCustomStats 是异步的，可能尚未就绪），
+ * 再按合成 ID 添加需求。
+ */
+async function selectWeaponFromQuery(weaponParam: string) {
+  if (isCustomStatId(weaponParam)) {
+    if (customStats.value.length === 0) {
+      await fetchCustomStats()
+    }
+    const found = findCustomStat(weaponParam, customStats.value)
+    if (!found) return
+    const stat = found.stat
+    if (!stat.attribute || !stat.secondary || !stat.skill) return
+    addStatFromCustomPreset(
+      weaponParam,
+      getStatDisplayName(stat.attribute),
+      getStatDisplayName(stat.secondary),
+      getStatDisplayName(stat.skill),
+    )
+    return
+  }
+  addStatFromWeapon(weaponParam)
+}
+
+/**
  * 在页面加载时处理 URL 参数。
  */
 onMounted(() => {
@@ -1011,6 +1038,11 @@ onMounted(() => {
   if (shouldClear) {
     // 从宝藏基质跳转过来，清空之前的选择
     clearAllStats()
+  }
+
+  const weaponParam = route.query.weapon
+  if (typeof weaponParam === 'string' && weaponParam) {
+    void selectWeaponFromQuery(weaponParam)
   }
 
   if (noPrecraft) {
@@ -1032,6 +1064,11 @@ watch(
 
     if (shouldClear) {
       clearAllStats()
+    }
+
+    const weaponParam = query.weapon
+    if (typeof weaponParam === 'string' && weaponParam) {
+      void selectWeaponFromQuery(weaponParam)
     }
 
     if (noPrecraft) {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -56,3 +56,29 @@ ol > li::marker {
   vertical-align: middle;
   border-radius: 4px;
 }
+
+// 自定义基质区段标题的小图标：底板 + 默认基质图标叠加
+.essence-icon-stack {
+  position: relative;
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  vertical-align: middle;
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  > img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  // 叠加层（默认基质图标）与技能属性图标同样向右下偏移 5%
+  > img + img {
+    transform: translate(5%, -5%);
+  }
+}

--- a/frontend/src/types/staticData.ts
+++ b/frontend/src/types/staticData.ts
@@ -41,6 +41,7 @@ export interface RarityColorResponse {
 
 export interface MatrixIconResponse {
   essenceBg: string
+  defaultIcon: string
   skills: Record<string, string>
 }
 

--- a/frontend/src/utils/gameData/staticData.ts
+++ b/frontend/src/utils/gameData/staticData.ts
@@ -17,7 +17,7 @@ const weaponsMap = ref<Map<string, WeaponInfo>>(new Map())
 const weaponTypes = ref<WeaponTypeInfo[]>([])
 const essencesMap = ref<Map<string, EssenceInfo>>(new Map())
 const rarityColors = ref<Record<number, string>>({})
-const matrixIcons = ref<MatrixIconResponse>({ essenceBg: '', skills: {} })
+const matrixIcons = ref<MatrixIconResponse>({ essenceBg: '', defaultIcon: '', skills: {} })
 const energyAlluviums = ref<EnergyAlluviumInfo[]>([])
 const isLoaded = ref(false)
 
@@ -55,6 +55,7 @@ async function fetchStaticData() {
         fetchJson<EnergyAlluviumListResponse>(`/api/static/energy_alluviums`),
         fetchOptionalJson<MatrixIconResponse>(`/api/static/matrix_icons`, {
           essenceBg: '',
+          defaultIcon: '',
           skills: {},
         }),
       ])

--- a/src/endfield_essence_recognizer/schemas/static_data.py
+++ b/src/endfield_essence_recognizer/schemas/static_data.py
@@ -115,6 +115,7 @@ class RarityColorResponse(BaseModel):
 
 class MatrixIconResponse(BaseModel):
     essence_bg: str = Field(description="基质底板图片的URL")
+    default_icon: str = Field(description="默认基质的图标URL（技能属性缺失时显示）")
     skills: dict[str, str] = Field(description="技能属性ID到图标URL的映射")
 
     model_config = ConfigDict(

--- a/src/endfield_essence_recognizer/services/static_data_service.py
+++ b/src/endfield_essence_recognizer/services/static_data_service.py
@@ -191,8 +191,8 @@ class StaticDataService:
         Get the mapping of matrix icon URLs.
 
         Returns:
-            A MatrixIconResponse containing the essence background URL
-            and skill stat ID to icon URL mapping.
+            A MatrixIconResponse containing the essence background URL,
+            the default essence icon URL, and skill stat ID to icon URL mapping.
         """
         # 技能属性ID到资源文件名的映射
         skill_icon_map = {
@@ -222,6 +222,7 @@ class StaticDataService:
 
         return MatrixIconResponse(
             essence_bg=f"{self.matrix_icon_base_url}item_gem_rarity_5.png",
+            default_icon=f"{self.matrix_icon_base_url}icon_wpngem_00.png",
             skills=skills,
         )
 

--- a/tests/unit/services/test_static_data_service.py
+++ b/tests/unit/services/test_static_data_service.py
@@ -50,6 +50,18 @@ def test_get_rarity_colors_service(service):
     assert response.colors[4].upper() == "#9452FA"
 
 
+def test_get_matrix_icons_service(service):
+    response = service.get_matrix_icons()
+    assert response.essence_bg.endswith("item_gem_rarity_5.png")
+    assert response.default_icon.endswith("icon_wpngem_00.png")
+    assert len(response.skills) > 0
+    for skill_id, icon_url in response.skills.items():
+        assert icon_url.startswith("/")
+        assert skill_id.startswith("gst_passive_") or skill_id.startswith(
+            "weapon.stat.gst_passive_"
+        )
+
+
 def test_get_essence_service(service):
     essences = service.list_essences().items
     assert len(essences) > 0, "Essence dataset must not be empty"


### PR DESCRIPTION
  ## 改动内容

  ### 1. 基质详情弹窗新增「查看最优刷取方案」按钮
  - 在 `WeaponDetailDialog` 中新增按钮，点击后携带当前基质 ID 跳转至基质规划页（`matrix-planner`）
  - 基质规划页通过 URL 参数 `weapon` 自动选中对应基质并加入需求列表，支持内置武器和自定义基质
  - 自定义基质名称输入框增加提示文案，字号与内置武器名保持一致

  ### 2. 技能属性图标缺失时兜底显示默认基质图标
  - 后端 `MatrixIconResponse` 新增 `default_icon` 字段，指向 `icon_wpngem_00.png`
  - 前端 `CustomStatIcon`、`WeaponOverview`、`matrix-planner` 中，当技能属性图标未匹配时回退到默认基质图标，避免显示空白
  - 新增 `.essence-icon-stack` 样式，实现底板与默认图标叠加显示
  - 同步 `resources` 子模块至包含默认基质图标的版本

  ### 3. 测试
  - 新增 `test_get_matrix_icons_service` 单测，验证 `default_icon` 字段及技能图标映射

  ## 涉及文件

  | 文件 | 改动 |
  |---|---|
  | `WeaponDetailDialog.vue` | 新增跳转按钮、`navigateToPlanner` 函数、自定义名称输入框样式优化 |
  | `matrix-planner.vue` | 新增 `selectWeaponFromQuery` 处理 URL 参数自动选中基质 |
  | `WeaponOverview.vue` | 自定义基质区段图标改为叠加样式，技能图标兜底逻辑 |
  | `CustomStatIcon.vue` | 技能属性图标缺失时回退到默认基质图标 |
  | `global.scss` | 新增 `.essence-icon-stack` 叠加图标样式 |
  | `staticData.ts` / `static_data.py` | `MatrixIconResponse` 新增 `default_icon` 字段 |
  | `static_data_service.py` | 返回默认基质图标 URL |
  | `test_static_data_service.py` | 新增 matrix_icons 接口单测 |
  | `resources` | 子模块更新 |

 ## images
<img width="1586" height="893" alt="image" src="https://github.com/user-attachments/assets/0a3cf87e-78bd-4797-9e90-3058407c1b1c" />

<img width="1586" height="893" alt="image" src="https://github.com/user-attachments/assets/6ac4be5e-09cd-43bb-a58d-4cbdb070bd15" />

