### PR TITLE
feat(settings): 自定义基质支持一键补齐全部属性组合与清空

### DIFF
--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -213,8 +213,53 @@
           <v-divider class="my-4" />
 
           <!-- 1-B: 额外属性匹配 -->
-          <h2>自定义基质 | 额外将以下属性的基质视为宝藏</h2>
-          <v-row v-for="(essenceStat, index) in treasureEssenceStats" :key="index" align="center">
+          <div class="d-flex align-center flex-wrap ga-2">
+            <h2>自定义基质 | 额外将以下属性的基质视为宝藏</h2>
+            <v-spacer />
+            <v-btn
+              color="primary"
+              prepend-icon="mdi-auto-fix"
+              size="small"
+              variant="tonal"
+              @click="prepareFillAllCombinations"
+            >
+              一键补齐全部组合
+              <v-tooltip activator="parent" location="bottom" max-width="360">
+                按「基础 × 附加 × 技能」生成全部
+                {{ totalCombinationCount }}
+                种属性组合，自动跳过内置武器已覆盖的组合与列表中已有的组合。
+              </v-tooltip>
+            </v-btn>
+            <v-btn
+              v-if="treasureEssenceStats.length > 0"
+              color="error"
+              prepend-icon="mdi-delete-sweep"
+              size="small"
+              variant="tonal"
+              @click="clearAllDialog = true"
+            >
+              清空全部
+            </v-btn>
+          </div>
+          <v-row v-if="customStatPageCount > 1" align="center" class="mt-0">
+            <v-col class="d-flex align-center flex-wrap ga-4 justify-center" cols="12">
+              <v-pagination
+                v-model="customStatPage"
+                density="comfortable"
+                :length="customStatPageCount"
+                rounded="circle"
+                :total-visible="7"
+              />
+              <span class="text-caption text-medium-emphasis">
+                共 {{ treasureEssenceStats.length }} 条，每页 {{ CUSTOM_STAT_PAGE_SIZE }} 条
+              </span>
+            </v-col>
+          </v-row>
+          <v-row
+            v-for="{ stat: essenceStat, index } in pagedCustomStats"
+            :key="essenceStat.id"
+            align="center"
+          >
             <v-col cols="12" md="3" sm="6">
               <v-text-field
                 v-model="essenceStat.name"
@@ -315,11 +360,7 @@
           </v-row>
           <v-row v-if="treasureEssenceStats.length === 0" class="my-4">
             <v-col cols="12">
-              <v-btn
-                color="primary"
-                prepend-icon="mdi-plus"
-                @click="treasureEssenceStats.push(newCustomStat())"
-              >
+              <v-btn color="primary" prepend-icon="mdi-plus" @click="appendCustomStat">
                 添加自定义宝藏基质
               </v-btn>
             </v-col>
@@ -327,12 +368,7 @@
           <v-row v-else>
             <v-col cols="12" md="9" sm="6" />
             <v-col cols="12" md="3" sm="6">
-              <v-btn
-                color="primary"
-                icon="mdi-plus"
-                variant="text"
-                @click="treasureEssenceStats.push(newCustomStat())"
-              />
+              <v-btn color="primary" icon="mdi-plus" variant="text" @click="appendCustomStat" />
             </v-col>
           </v-row>
         </v-expansion-panel-text>
@@ -807,6 +843,59 @@
         配置版本: v{{ configVersion }}
       </v-card-text>
     </v-card>
+
+    <!-- 一键补齐全部属性组合的确认弹窗 -->
+    <v-dialog v-model="fillAllDialog" max-width="520">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon class="mr-2">mdi-auto-fix</v-icon>
+          一键补齐全部属性组合
+        </v-card-title>
+        <v-card-text>
+          <p class="mb-2">
+            基础 {{ allAttributeStats.length }} × 附加 {{ allSecondaryStats.length }} × 技能
+            {{ allSkillStats.length }} 共 {{ totalCombinationCount }} 种组合，其中
+            {{ totalCombinationCount - pendingFullMatrix.length }}
+            种已被内置武器或现有条目覆盖。
+          </p>
+          <p class="mb-4">
+            本次将新增 <strong>{{ pendingFullMatrix.length }}</strong> 条自定义基质，名称由「基础 2
+            字 + 附加 2 字 + 技能 1 字」拼成 5 个字，例如 {{ pendingFullMatrix[0]?.name }}。
+          </p>
+          <v-alert border="start" density="compact" type="warning" variant="tonal">
+            条目数量较多会明显拖慢设置页与宝藏基质页的渲染，请确认后再继续。
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="fillAllDialog = false">取消</v-btn>
+          <v-btn color="primary" variant="flat" @click="confirmFillAllCombinations">确认添加</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- 清空全部自定义基质的确认弹窗 -->
+    <v-dialog v-model="clearAllDialog" max-width="520">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon class="mr-2">mdi-delete-sweep</v-icon>
+          清空全部自定义基质
+        </v-card-title>
+        <v-card-text>
+          <p class="mb-4">
+            将删除全部 <strong>{{ treasureEssenceStats.length }}</strong> 条自定义基质配置。
+          </p>
+          <v-alert border="start" density="compact" type="warning" variant="tonal">
+            此操作不可撤销。与逐条删除一样，只清除设置中的配置，宝藏基质页里已记录的对应条目需自行清理。
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="clearAllDialog = false">取消</v-btn>
+          <v-btn color="error" variant="flat" @click="confirmClearAllCustomStats">确认清空</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -815,9 +904,12 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useTheme } from 'vuetify'
 import ItemIcon from '@/components/ItemIcon.vue'
 import { setScanningStatusPolling, useScanningStatus } from '@/composables/useScanningStatus'
+import { useToast } from '@/composables/useToast'
 import { useUpdateMirrors } from '@/composables/useUpdateMirrors'
 import { useStaticData } from '@/utils/gameData/staticData'
 import {
+  buildFullCustomStatMatrix,
+  buildStatKey,
   createCustomStatId,
   type CustomStat,
   getGemTagName,
@@ -902,6 +994,98 @@ const updateMirrorChyanResId = ref('')
 const updateMirrorChyanCdk = ref('')
 const updateMirrorChyanUserAgent = ref('EER_APP')
 const weaponEssenceCounts = ref<Record<string, number>>({})
+
+/** 自定义基质列表每页条目数：一次性渲染上百行下拉框会让设置页长时间无响应 */
+const CUSTOM_STAT_PAGE_SIZE = 10
+const customStatPage = ref(1)
+
+/** 一键补齐的候选条目，用户在弹窗中确认后才写入列表 */
+const pendingFullMatrix = ref<CustomStat[]>([])
+const fillAllDialog = ref(false)
+const clearAllDialog = ref(false)
+
+const customStatPageCount = computed(() =>
+  Math.max(1, Math.ceil(treasureEssenceStats.value.length / CUSTOM_STAT_PAGE_SIZE)),
+)
+
+/**
+ * 当前页的自定义基质，附带其在完整列表中的下标。
+ *
+ * 增删改与上下移动都直接作用于 `treasureEssenceStats`，所以这里必须把全局下标
+ * 一并带出去，否则翻到第二页后所有操作都会打到列表开头的条目上。
+ */
+const pagedCustomStats = computed(() => {
+  const start = (customStatPage.value - 1) * CUSTOM_STAT_PAGE_SIZE
+  return treasureEssenceStats.value
+    .slice(start, start + CUSTOM_STAT_PAGE_SIZE)
+    .map((stat, offset) => ({ stat, index: start + offset }))
+})
+
+/** 基础 × 附加 × 技能 的理论组合总数 */
+const totalCombinationCount = computed(
+  () =>
+    allAttributeStats.value.length * allSecondaryStats.value.length * allSkillStats.value.length,
+)
+
+// 删除条目使总页数变少时，把当前页拉回有效范围，避免停在一页空白上
+watch(customStatPageCount, (count) => {
+  if (customStatPage.value > count) {
+    customStatPage.value = count
+  }
+})
+
+/**
+ * 计算「一键补齐」会新增哪些条目并弹窗确认。
+ *
+ * 内置武器已覆盖的组合和列表中已有的组合都算作已占用，因此重复点击不会产生重复条目。
+ */
+function prepareFillAllCombinations() {
+  const occupiedKeys = new Set<string>()
+  for (const weapon of weaponsMap.value.values()) {
+    occupiedKeys.add(
+      buildStatKey(weapon.attributeStatId, weapon.secondaryStatId, weapon.skillStatId),
+    )
+  }
+  for (const stat of treasureEssenceStats.value) {
+    occupiedKeys.add(buildStatKey(stat.attribute, stat.secondary, stat.skill))
+  }
+
+  const generated = buildFullCustomStatMatrix(
+    allAttributeStats.value,
+    allSecondaryStats.value,
+    allSkillStats.value,
+    occupiedKeys,
+  )
+  if (generated.length === 0) {
+    useToast().info('全部属性组合都已被内置武器或现有条目覆盖，无需补齐')
+    return
+  }
+
+  pendingFullMatrix.value = generated
+  fillAllDialog.value = true
+}
+
+/** 确认后把候选条目追加到列表末尾 */
+function confirmFillAllCombinations() {
+  fillAllDialog.value = false
+  treasureEssenceStats.value = [...treasureEssenceStats.value, ...pendingFullMatrix.value]
+  useToast().success(`已添加 ${pendingFullMatrix.value.length} 条自定义基质`)
+}
+
+/** 在列表末尾追加一条空白自定义基质，并翻到它所在的页 */
+function appendCustomStat() {
+  treasureEssenceStats.value.push(newCustomStat())
+  customStatPage.value = customStatPageCount.value
+}
+
+/** 确认后清空全部自定义基质，并回到第一页 */
+function confirmClearAllCustomStats() {
+  const clearedCount = treasureEssenceStats.value.length
+  clearAllDialog.value = false
+  treasureEssenceStats.value = []
+  customStatPage.value = 1
+  useToast().success(`已清空 ${clearedCount} 条自定义基质`)
+}
 
 const notSelectedWeaponIds = computed(() => {
   return Array.from(weaponsMap.value.keys()).filter(

--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -886,7 +886,7 @@
             将删除全部 <strong>{{ treasureEssenceStats.length }}</strong> 条自定义基质配置。
           </p>
           <v-alert border="start" density="compact" type="warning" variant="tonal">
-            此操作不可撤销。与逐条删除一样，只清除设置中的配置，宝藏基质页里已记录的对应条目需自行清理。
+            此操作不可撤销。与逐条删除一样，宝藏基质页中对应的已记录条目会一并移除。
           </v-alert>
         </v-card-text>
         <v-card-actions>

--- a/frontend/src/utils/gameData/__tests__/weapon.test.ts
+++ b/frontend/src/utils/gameData/__tests__/weapon.test.ts
@@ -8,7 +8,9 @@
 import type { CustomStat } from '../weapon'
 
 import { describe, expect, it } from 'vitest'
+import { useStaticData } from '../staticData'
 import {
+  buildFullCustomStatMatrix,
   buildStatKey,
   createCustomStatId,
   CUSTOM_ID_PREFIX,
@@ -122,5 +124,78 @@ describe('fallbackCustomStatName', () => {
   it('按 1 起编号', () => {
     expect(fallbackCustomStatName(0)).toBe('自定义基质 1')
     expect(fallbackCustomStatName(4)).toBe('自定义基质 5')
+  })
+})
+
+describe('buildFullCustomStatMatrix', () => {
+  const ATTRIBUTES = ['gat_passive_attr_agi', 'gat_passive_attr_main']
+  const SECONDARIES = ['gat_passive_attr_atk', 'gat_passive_attr_firedam', 'gat_passive_attr_usp']
+  const SKILLS = ['gst_passive_tacafter', 'gst_passive_ult']
+
+  /** 装载短名所依赖的词条静态数据，未装载时 getGemTagName 只会回显 ID */
+  function loadEssences() {
+    const { essencesMap } = useStaticData()
+    essencesMap.value = new Map(
+      (
+        [
+          ['gat_passive_attr_agi', '敏捷提升', 'ATTRIBUTE'],
+          ['gat_passive_attr_main', '主能力提升', 'ATTRIBUTE'],
+          ['gat_passive_attr_atk', '攻击提升', 'SECONDARY'],
+          ['gat_passive_attr_firedam', '灼热伤害提升', 'SECONDARY'],
+          ['gat_passive_attr_usp', '终结技充能效率提升', 'SECONDARY'],
+          ['gst_passive_tacafter', '流转', 'SKILL'],
+          ['gst_passive_ult', '夜幕', 'SKILL'],
+        ] as const
+      ).map(([id, name, type]) => [id, { id, name, tagName: name, type }]),
+    )
+  }
+
+  it('生成三个维度的笛卡尔积', () => {
+    loadEssences()
+    const generated = buildFullCustomStatMatrix(ATTRIBUTES, SECONDARIES, SKILLS, new Set())
+    expect(generated).toHaveLength(2 * 3 * 2)
+    const keys = new Set(generated.map((s) => buildStatKey(s.attribute, s.secondary, s.skill)))
+    expect(keys.size).toBe(12)
+  })
+
+  it('跳过已被占用的属性组合', () => {
+    loadEssences()
+    const occupied = new Set([
+      buildStatKey('gat_passive_attr_agi', 'gat_passive_attr_atk', 'gst_passive_ult'),
+    ])
+    const generated = buildFullCustomStatMatrix(ATTRIBUTES, SECONDARIES, SKILLS, occupied)
+    expect(generated).toHaveLength(11)
+    expect(
+      generated.some((s) => buildStatKey(s.attribute, s.secondary, s.skill) === [...occupied][0]),
+    ).toBe(false)
+  })
+
+  it('按「基础 2 字 + 附加 2 字 + 技能 1 字」命名', () => {
+    loadEssences()
+    const generated = buildFullCustomStatMatrix(ATTRIBUTES, SECONDARIES, SKILLS, new Set())
+    const names = generated.map((s) => s.name)
+    expect(names.every((name) => name?.length === 5)).toBe(true)
+    // 属性通用规则：去「提升」后缀；技能查简称表（流转 → 流）
+    expect(names).toContain('敏捷攻击流')
+    // 属性通用规则：再去「伤害」后缀；技能简称取末字（夜幕 → 夜）
+    expect(names).toContain('敏捷灼热夜')
+    // 属性截断到 2 字（主能力提升 → 主能）+ 属性覆盖表（终结技充能效率提升 → 充能）
+    expect(names).toContain('主能充能流')
+  })
+
+  it('每条都带互不相同的稳定 ID', () => {
+    loadEssences()
+    const generated = buildFullCustomStatMatrix(ATTRIBUTES, SECONDARIES, SKILLS, new Set())
+    expect(new Set(generated.map((s) => s.id)).size).toBe(generated.length)
+  })
+
+  it('全部组合都被占用时返回空列表', () => {
+    loadEssences()
+    const occupied = new Set(
+      ATTRIBUTES.flatMap((a) =>
+        SECONDARIES.flatMap((s) => SKILLS.map((k) => buildStatKey(a, s, k))),
+      ),
+    )
+    expect(buildFullCustomStatMatrix(ATTRIBUTES, SECONDARIES, SKILLS, occupied)).toEqual([])
   })
 })

--- a/frontend/src/utils/gameData/weapon.ts
+++ b/frontend/src/utils/gameData/weapon.ts
@@ -25,6 +25,60 @@ export function getGemTagName(gemId: string): string {
   return essence.tagName
 }
 
+/**
+ * 基础 / 附加属性的短名覆盖表：只收录通用规则算不出正确结果的词条。
+ *
+ * 其余词条交给 getStatShortName 的通用规则处理，游戏新增词条时无需维护此表。
+ */
+const STAT_SHORT_NAME_OVERRIDES: Record<string, string> = {
+  gat_passive_attr_usp: '充能', // 终结技充能效率提升
+}
+
+/**
+ * 技能词条的单字简称。
+ *
+ * 取首字还是取末字全看哪个字更有辨识度（「粉碎」取「碎」、「流转」取「流」），
+ * 没有可靠的通用规则，因此逐条列出；十四个字互不相同，缩写后不会撞名。
+ */
+const SKILL_SHORT_NAMES: Record<string, string> = {
+  gst_passive_break: '暴', // 残暴
+  gst_passive_burst: '迸', // 迸发
+  gst_passive_combo: '袭', // 追袭
+  gst_passive_crit: '骨', // 切骨
+  gst_passive_force: '攻', // 强攻
+  gst_passive_heal: '疗', // 医疗
+  gst_passive_keyword: '益', // 效益
+  gst_passive_magabn: '术', // 附术
+  gst_passive_phyabn: '巧', // 巧技
+  gst_passive_smash: '碎', // 粉碎
+  gst_passive_spirit: '昂', // 昂扬
+  gst_passive_tacafter: '流', // 流转
+  gst_passive_tactic: '压', // 压制
+  gst_passive_ult: '夜', // 夜幕
+}
+
+/**
+ * 取基础 / 附加属性词条的 2 字短名。
+ *
+ * 通用规则：去掉「提升」后缀，再去掉「伤害 / 效率」这类修饰后缀，最后截断到 2 个字。
+ * 例：「敏捷提升」→「敏捷」、「灼热伤害提升」→「灼热」、「主能力提升」→「主能」。
+ */
+function getStatShortName(gemId: string): string {
+  const override = STAT_SHORT_NAME_OVERRIDES[gemId]
+  if (override !== undefined) {
+    return override
+  }
+  return getGemTagName(gemId)
+    .replace(/提升$/, '')
+    .replace(/(?:伤害|效率)$/, '')
+    .slice(0, 2)
+}
+
+/** 取技能词条的 1 字简称，表外的新词条退化为取首字。 */
+function getSkillShortName(gemId: string): string {
+  return SKILL_SHORT_NAMES[gemId] ?? getGemTagName(gemId).slice(0, 1)
+}
+
 export function getStatsForWeapon(weaponId: string): EssenceStat {
   const { weaponsMap } = useStaticData()
   const weapon = weaponsMap.value.get(weaponId)
@@ -133,6 +187,43 @@ export function findCustomStat(
 /** 自定义基质的兜底显示名（配置里没填名称时使用）。 */
 export function fallbackCustomStatName(index: number): string {
   return `自定义基质 ${index + 1}`
+}
+
+/**
+ * 生成「基础 × 附加 × 技能」的全部属性组合作为新的自定义基质。
+ *
+ * 已被占用的组合直接跳过，因此重复调用不会产生重复条目。
+ *
+ * @param attributeIds 基础属性词条 ID 列表
+ * @param secondaryIds 附加属性词条 ID 列表
+ * @param skillIds 技能属性词条 ID 列表
+ * @param occupiedKeys 已被占用的属性组合键（由 buildStatKey 生成），命中的组合会被跳过
+ * @returns 新建条目，每条都带稳定 ID 和「基础 2 字 + 附加 2 字 + 技能 1 字」的 5 字显示名
+ */
+export function buildFullCustomStatMatrix(
+  attributeIds: readonly string[],
+  secondaryIds: readonly string[],
+  skillIds: readonly string[],
+  occupiedKeys: ReadonlySet<string>,
+): CustomStat[] {
+  const generated: CustomStat[] = []
+  for (const attribute of attributeIds) {
+    for (const secondary of secondaryIds) {
+      for (const skill of skillIds) {
+        if (occupiedKeys.has(buildStatKey(attribute, secondary, skill))) {
+          continue
+        }
+        generated.push({
+          id: createCustomStatId(),
+          name: `${getStatShortName(attribute)}${getStatShortName(secondary)}${getSkillShortName(skill)}`,
+          attribute,
+          secondary,
+          skill,
+        })
+      }
+    }
+  }
+  return generated
 }
 
 /**

--- a/src/endfield_essence_recognizer/api/routes/config.py
+++ b/src/endfield_essence_recognizer/api/routes/config.py
@@ -4,6 +4,7 @@ from endfield_essence_recognizer.api.routes.profiles import get_profile_manager
 from endfield_essence_recognizer.dependencies import get_user_setting_manager_dep
 from endfield_essence_recognizer.exceptions import ConfigVersionMismatchError
 from endfield_essence_recognizer.schemas.user_setting import UserSetting
+from endfield_essence_recognizer.services.profile_manager import ProfileManager
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 
 router = APIRouter(prefix="/config", tags=["user setting"])
@@ -20,17 +21,31 @@ async def get_config(
 async def post_config(
     new_config: UserSetting = Body(),
     user_setting_manager: UserSettingManager = Depends(get_user_setting_manager_dep),
+    profile_manager: ProfileManager = Depends(get_profile_manager),
 ) -> UserSetting:
+    """保存设置。
+
+    自定义基质被删除后（逐条删除、清空全部、重合检测），各账号里指向它的
+    宝藏基质条目会失去属性来源，因此保存成功后按最新配置剪除失效引用，
+    让所有删除路径都与 profile 联动，而不必各自记得清理。
+
+    白名单取自保存后的内存配置而非请求体：`update_from_user_setting` 会为
+    缺失 ID 的新条目补齐稳定 ID，直接读请求体会把它们误判成孤儿。
+    """
     try:
         user_setting_manager.update_from_user_setting(new_config)
     except ConfigVersionMismatchError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    profile_manager.prune_custom_stat_refs(
+        set(user_setting_manager.get_custom_stat_ids())
+    )
     return user_setting_manager.get_user_setting_ref()
 
 
 @router.post("/reset")
 async def reset_config(
     user_setting_manager: UserSettingManager = Depends(get_user_setting_manager_dep),
+    profile_manager: ProfileManager = Depends(get_profile_manager),
 ) -> UserSetting:
     """将所有设置重置为默认值。
 
@@ -38,5 +53,5 @@ async def reset_config(
     避免界面出现指向不存在基质的幽灵条目。
     """
     user_setting_manager.reset_to_default()
-    get_profile_manager().remove_custom_stat_refs()
+    profile_manager.prune_custom_stat_refs(set())
     return user_setting_manager.get_user_setting_ref()

--- a/src/endfield_essence_recognizer/services/profile_manager.py
+++ b/src/endfield_essence_recognizer/services/profile_manager.py
@@ -303,46 +303,77 @@ class ProfileManager:
                 logger.info("已将失效的内置武器引用迁移为最新 ID")
             return changed
 
-    def remove_custom_stat_refs(self) -> bool:
-        """移除所有账号中对自定义基质的引用（配置被重置/清空后调用）。
+    def prune_custom_stat_refs(self, valid_ids: set[str]) -> bool:
+        """移除所有账号中指向已不存在自定义基质的引用。
 
-        自定义基质随配置重置而被删除，但各账号的矩阵与优先级里仍可能残留
-        `custom:{id}` 引用；逐账号清理会让引用永远指向不存在的基质，在
-        界面上表现为无法操作的幽灵条目。
+        自定义基质被删除后，各账号的矩阵与优先级里仍残留 `custom:{id}` 引用。
+        这类引用查不到属性来源，在界面上表现为属性未知、不参与任何判定的幽灵
+        条目；而稳定 ID 是一次性 UUID，重新添加相同属性组合只会生成新 ID，
+        旧引用永远无法复活，因此没有保留价值。
+
+        旧格式 `custom_stat_{下标}` 一律视为失效：启动时的
+        `migrate_custom_stat_ids` 已把可解析的引用改写成新格式，运行期还能
+        遇到的必然是当时就解析不出的孤儿。
+
+        Args:
+            valid_ids: 当前配置中存活的自定义基质稳定 ID（不含 `custom:` 前缀）。
+                传入空集合表示配置里一条自定义基质都不剩，即清除全部引用。
 
         Returns:
             是否发生了变更（调用方据此决定是否需要写盘）。
         """
         with self._lock:
+            live_refs = {f"{CUSTOM_ID_PREFIX}{stat_id}" for stat_id in valid_ids}
+
+            def is_orphan(weapon_id: str) -> bool:
+                """该引用指向自定义基质，但在当前配置中已找不到对应条目。"""
+                if weapon_id.startswith(LEGACY_CUSTOM_ID_PREFIX):
+                    return True
+                return (
+                    weapon_id.startswith(CUSTOM_ID_PREFIX)
+                    and weapon_id not in live_refs
+                )
+
+            def has_orphan(profile: ProfileData) -> bool:
+                return any(
+                    is_orphan(entry.weapon_id) for entry in profile.treasure_matrix
+                ) or any(
+                    is_orphan(weapon_id) for weapon_id in profile.weapon_priorities
+                )
+
+            # 先只读探测：设置页每次改动都会保存一次配置，无谓的深拷贝会被放大。
+            if not any(has_orphan(p) for p in self._collection.profiles.values()):
+                return False
+
             collection = self._collection.model_copy(deep=True)
-            changed = False
+            dropped_entries = 0
+            dropped_priorities = 0
             for profile in collection.profiles.values():
                 kept_matrix = [
                     entry
                     for entry in profile.treasure_matrix
-                    if not (
-                        entry.weapon_id.startswith(CUSTOM_ID_PREFIX)
-                        or entry.weapon_id.startswith(LEGACY_CUSTOM_ID_PREFIX)
-                    )
+                    if not is_orphan(entry.weapon_id)
                 ]
-                if len(kept_matrix) != len(profile.treasure_matrix):
-                    profile.treasure_matrix = kept_matrix
-                    changed = True
-                custom_priorities = [
-                    weapon_id
-                    for weapon_id in profile.weapon_priorities
-                    if weapon_id.startswith(CUSTOM_ID_PREFIX)
-                    or weapon_id.startswith(LEGACY_CUSTOM_ID_PREFIX)
-                ]
-                if custom_priorities:
-                    for weapon_id in custom_priorities:
-                        del profile.weapon_priorities[weapon_id]
-                    changed = True
+                dropped_entries += len(profile.treasure_matrix) - len(kept_matrix)
+                profile.treasure_matrix = kept_matrix
 
-            if changed:
-                self._commit_collection_unlocked(collection)
-                logger.info("已清理所有账号中对自定义基质的引用")
-            return changed
+                kept_priorities = {
+                    weapon_id: priority
+                    for weapon_id, priority in profile.weapon_priorities.items()
+                    if not is_orphan(weapon_id)
+                }
+                dropped_priorities += len(profile.weapon_priorities) - len(
+                    kept_priorities
+                )
+                profile.weapon_priorities = kept_priorities
+
+            self._commit_collection_unlocked(collection)
+            logger.info(
+                "已清理指向已删除自定义基质的引用：{} 条宝藏基质条目、{} 个优先级键",
+                dropped_entries,
+                dropped_priorities,
+            )
+            return True
 
     def _save_unlocked(self) -> None:
         """保存账号配置；调用方必须已经持有 `_lock`。"""

--- a/tests/integration/test_user_setting_api.py
+++ b/tests/integration/test_user_setting_api.py
@@ -3,8 +3,11 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
+from endfield_essence_recognizer.api.routes.profiles import get_profile_manager
 from endfield_essence_recognizer.dependencies import get_user_setting_manager_dep
+from endfield_essence_recognizer.schemas.profile import TreasureMatrixEntry
 from endfield_essence_recognizer.server import app
+from endfield_essence_recognizer.services.profile_manager import ProfileManager
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 
 
@@ -21,15 +24,31 @@ def test_manager(test_settings_file):
 
 
 @pytest.fixture
-def client(test_manager):
+def test_profile_manager(tmp_path):
+    """使用临时文件的账号管理器。
+
+    保存配置会顺带剪除失效的自定义基质引用，若不隔离，测试会直接改写
+    开发者本机的 profiles.json。
+    """
+    manager = ProfileManager(tmp_path / "profiles.json")
+    manager.load()
+    return manager
+
+
+@pytest.fixture
+def client(test_manager, test_profile_manager):
     """Fixture for a FastAPI TestClient with overridden dependencies."""
 
     def override_get_user_setting_manager():
         return test_manager
 
+    def override_get_profile_manager():
+        return test_profile_manager
+
     app.dependency_overrides[get_user_setting_manager_dep] = (
         override_get_user_setting_manager
     )
+    app.dependency_overrides[get_profile_manager] = override_get_profile_manager
     with TestClient(app) as client:
         yield client
     app.dependency_overrides.clear()
@@ -89,3 +108,77 @@ def test_post_config_version_mismatch(client, test_manager):
     assert "version mismatch" in response.json()["detail"].lower()
     assert str(UserSetting._VERSION) in response.json()["detail"]
     assert "-1" in response.json()["detail"]
+
+
+def _seed_custom_refs(manager: ProfileManager) -> None:
+    """写入两条自定义基质引用和一条普通武器引用。"""
+    manager.update_treasure_matrix(
+        [
+            TreasureMatrixEntry(
+                weapon_id="custom:live", weapon_name="L", affix1_level=3, priority=5
+            ),
+            TreasureMatrixEntry(
+                weapon_id="custom:gone", weapon_name="G", affix1_level=2, priority=3
+            ),
+            TreasureMatrixEntry(
+                weapon_id="wpn_normal", weapon_name="N", affix1_level=1, priority=4
+            ),
+        ]
+    )
+
+
+def test_post_config_prunes_deleted_custom_stat_refs(client, test_profile_manager):
+    """删掉一条自定义基质后保存，profile 里指向它的条目一并移除。"""
+    _seed_custom_refs(test_profile_manager)
+
+    response = client.post(
+        "/api/config",
+        json={
+            "treasure_essence_stats": [
+                {"id": "live", "name": "保留", "attribute": None}
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    profile = test_profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == [
+        "custom:live",
+        "wpn_normal",
+    ]
+    assert profile.weapon_priorities == {"custom:live": 5, "wpn_normal": 4}
+
+
+def test_post_config_keeps_refs_of_live_custom_stats(client, test_profile_manager):
+    """自定义基质都还在时，保存配置不得动 profile。"""
+    _seed_custom_refs(test_profile_manager)
+
+    response = client.post(
+        "/api/config",
+        json={
+            "treasure_essence_stats": [
+                {"id": "live", "name": "A", "attribute": None},
+                {"id": "gone", "name": "B", "attribute": None},
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    profile = test_profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == [
+        "custom:live",
+        "custom:gone",
+        "wpn_normal",
+    ]
+
+
+def test_reset_config_prunes_all_custom_stat_refs(client, test_profile_manager):
+    """重置配置清空自定义基质，profile 中所有 custom 引用一并移除。"""
+    _seed_custom_refs(test_profile_manager)
+
+    response = client.post("/api/config/reset")
+    assert response.status_code == 200
+
+    profile = test_profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == ["wpn_normal"]
+    assert profile.weapon_priorities == {"wpn_normal": 4}

--- a/tests/unit/services/test_profile_manager.py
+++ b/tests/unit/services/test_profile_manager.py
@@ -904,15 +904,15 @@ def test_migrate_stale_weapon_ids_covers_all_profiles(
         assert ids == ["wpn_lance_0101", "wpn_sword_0001"]
 
 
-def test_remove_custom_stat_refs_cleans_all_profiles(profile_manager: ProfileManager):
-    """清理自定义引用：覆盖全部账号的矩阵与优先级，普通武器不受影响。"""
+def test_prune_custom_stat_refs_cleans_all_profiles(profile_manager: ProfileManager):
+    """空白名单清理自定义引用：覆盖全部账号的矩阵与优先级，普通武器不受影响。"""
     profile_manager.load()
     profile_manager.switch_profile("alt")
     _seed_legacy_custom_refs(profile_manager)
     profile_manager.switch_profile("default")
     _seed_legacy_custom_refs(profile_manager)
 
-    assert profile_manager.remove_custom_stat_refs() is True
+    assert profile_manager.prune_custom_stat_refs(set()) is True
 
     for name in ("default", "alt"):
         profile = profile_manager.get_collection().profiles[name]
@@ -920,7 +920,7 @@ def test_remove_custom_stat_refs_cleans_all_profiles(profile_manager: ProfileMan
         assert profile.weapon_priorities == {"wpn_normal": 4}
 
 
-def test_remove_custom_stat_refs_cleans_new_format(profile_manager: ProfileManager):
+def test_prune_custom_stat_refs_cleans_new_format(profile_manager: ProfileManager):
     """新格式 custom:{id} 引用同样被清理。"""
     profile_manager.load()
     profile_manager.update_treasure_matrix(
@@ -934,18 +934,95 @@ def test_remove_custom_stat_refs_cleans_new_format(profile_manager: ProfileManag
         ]
     )
 
-    assert profile_manager.remove_custom_stat_refs() is True
+    assert profile_manager.prune_custom_stat_refs(set()) is True
 
     profile = profile_manager.get_active_profile()
     assert [e.weapon_id for e in profile.treasure_matrix] == ["wpn_normal"]
     assert profile.weapon_priorities == {}
 
 
-def test_remove_custom_stat_refs_no_custom_refs(profile_manager: ProfileManager):
+def test_prune_custom_stat_refs_no_custom_refs(profile_manager: ProfileManager):
     """没有自定义引用时不写盘。"""
     profile_manager.load()
     profile_manager.update_treasure_matrix(
         [TreasureMatrixEntry(weapon_id="wpn_001", weapon_name="W", affix1_level=1)]
     )
 
-    assert profile_manager.remove_custom_stat_refs() is False
+    assert profile_manager.prune_custom_stat_refs(set()) is False
+
+
+def test_prune_custom_stat_refs_keeps_live_ids(profile_manager: ProfileManager):
+    """白名单内的引用保留，只有配置里已删除的那条被剪掉。"""
+    profile_manager.load()
+    profile_manager.update_treasure_matrix(
+        [
+            TreasureMatrixEntry(
+                weapon_id="custom:live", weapon_name="L", affix1_level=3, priority=5
+            ),
+            TreasureMatrixEntry(
+                weapon_id="custom:gone", weapon_name="G", affix1_level=2, priority=3
+            ),
+            TreasureMatrixEntry(
+                weapon_id="wpn_normal", weapon_name="N", affix1_level=1, priority=4
+            ),
+        ]
+    )
+
+    assert profile_manager.prune_custom_stat_refs({"live"}) is True
+
+    profile = profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == [
+        "custom:live",
+        "wpn_normal",
+    ]
+    assert profile.weapon_priorities == {"custom:live": 5, "wpn_normal": 4}
+
+
+def test_prune_custom_stat_refs_all_ids_live(profile_manager: ProfileManager):
+    """全部引用都在白名单内时不写盘——设置页每次改动都会调用，不能有无谓写入。"""
+    profile_manager.load()
+    profile_manager.update_treasure_matrix(
+        [
+            TreasureMatrixEntry(
+                weapon_id="custom:live", weapon_name="L", affix1_level=3, priority=5
+            ),
+            TreasureMatrixEntry(
+                weapon_id="wpn_normal", weapon_name="N", affix1_level=1
+            ),
+        ]
+    )
+
+    assert profile_manager.prune_custom_stat_refs({"live", "unused"}) is False
+
+
+def test_prune_custom_stat_refs_drops_legacy_refs(profile_manager: ProfileManager):
+    """旧格式引用一律剪掉：启动迁移之后还残留的必然解析不出对应条目。"""
+    profile_manager.load()
+    _seed_legacy_custom_refs(profile_manager)
+
+    assert profile_manager.prune_custom_stat_refs({"aaa", "bbb", "ccc"}) is True
+
+    profile = profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == ["wpn_normal"]
+    assert profile.weapon_priorities == {"wpn_normal": 4}
+
+
+def test_prune_custom_stat_refs_cleans_orphan_priority_only(
+    profile_manager: ProfileManager,
+):
+    """矩阵里没有孤儿、只有优先级键是孤儿时也要清理。"""
+    profile_manager.load()
+    profile_manager.update_treasure_matrix(
+        [
+            TreasureMatrixEntry(
+                weapon_id="wpn_normal", weapon_name="N", affix1_level=1, priority=4
+            )
+        ]
+    )
+    profile_manager.update_weapon_priority("custom:gone", 7)
+
+    assert profile_manager.prune_custom_stat_refs(set()) is True
+
+    profile = profile_manager.get_active_profile()
+    assert [e.weapon_id for e in profile.treasure_matrix] == ["wpn_normal"]
+    assert profile.weapon_priorities == {"wpn_normal": 4}


### PR DESCRIPTION
自定义基质此前只能逐条手工配置，凑齐全部属性组合需要重复几百次相同操作，补上批量入口。

一键补齐：
按「基础 5 × 附加 12 × 技能 14」生成全部 840 种组合，
以属性组合为键跳过内置武器已覆盖的 64 种和列表中已有的条目，
首次点击实际新增 776 条，重复点击不会产生重复项。

生成的名称由「基础 2 字 + 附加 2 字 + 技能 1 字」拼成固定 5 字（如 敏捷攻击流），
840 个名称互不重复，便于在武器总览里辨认；

缩写以通用规则为主（去「提升」「伤害」「效率」后缀再截断），
只对规则算不对的词条和全部技能词条维护覆盖表。

清空全部：
与逐条删除一样不可撤销，加了确认弹窗，事先说明将删除多少条。

删除联动：
自定义基质被删除后（逐条删除、清空全部、重置配置），各账号里指向它的
宝藏基质条目会失去属性来源，因此保存成功后按最新配置剪除失效引用，
让所有删除路径都与 profile 联动，而不必各自记得清理。

添加只读探测：
无失效引用时跳过深拷贝和写盘，避免设置页频繁保存带来的开销。
旧格式 custom_stat_{idx} 引用一律视为失效（启动迁移后残留的必然是孤儿）。

自定义基质列表同时改为每页 10 条：
一次性渲染几百行下拉框会让设置页长时间无响应。
当前页的条目携带其在完整列表中的下标，增删和上下移动仍作用于完整列表，翻页不影响既有操作。