### PR TITLE
fix(claimer): 修复无匹配武器时留大弃小失效及词条顺序导致分组错误

### DIFF
--- a/src/endfield_essence_recognizer/core/scanner/claimer.py
+++ b/src/endfield_essence_recognizer/core/scanner/claimer.py
@@ -18,6 +18,7 @@ from endfield_essence_recognizer.core.scanner.classifier import (
 from endfield_essence_recognizer.core.scanner.evaluate import (
     _group_stat_key,
     _level_cmp,
+    _normalize_by_stat_type,
     _order_candidate_ids,
 )
 from endfield_essence_recognizer.core.scanner.models import (
@@ -228,12 +229,10 @@ class ClaimContext:
                 classification.matched_weapon_ids, setting, static_game_data
             )
 
-        current_levels: LevelTuple = (
-            data.levels[0] or 1,
-            data.levels[1] or 1,
-            data.levels[2] or 1,
+        # 归一化为语义顺序（属性、副属性、技能），与武器 stat1/2/3、profile affix1/2/3 对齐
+        stat_key, stat_types, current_levels = _normalize_by_stat_type(
+            data.stats, data.stat_types, data.levels
         )
-        stat_types = data.stat_types
         matched_weapon_ids = classification.matched_weapon_ids
 
         # 数量上限关闭
@@ -279,7 +278,6 @@ class ClaimContext:
             )
 
         # 默认按基质分组
-        stat_key = tuple(data.stats)
         return self._claim_by_matrix(
             classification,
             stat_key,

--- a/src/endfield_essence_recognizer/core/scanner/claimer.py
+++ b/src/endfield_essence_recognizer/core/scanner/claimer.py
@@ -717,30 +717,27 @@ class ClaimContext:
         stat_label = _format_stat_key(stat_key, static_game_data)
 
         if not matched_weapon_ids:
+            # 留大弃小优先于数量上限：更优基质替换组内已保存的那一枚（替换语义，不增计数）
+            if keep_best and self._try_keep_best(
+                stat_key, current_levels, mode, stat_types
+            ):
+                return ClaimResult()
+
+            # 数量上限：未达上限则新增并计数
+            if self._try_claim_slot(
+                stat_key, current_levels, limit, keep_best, mode, stat_types
+            ):
+                return ClaimResult()
+
+            # 未被认领：未达上限说明是被留大弃小拦下的更差基质
             count = self.treasure_counts.get(stat_key, 0)
-            if count >= limit:
-                logger.debug(
-                    f"[数量上限] 属性组合 [{stat_label}] 已达上限 {count}/{limit}"
-                )
-                return ClaimResult(
-                    reject_reason=RejectReason.LIMIT,
-                    current_count=count,
-                )
-            best = self.best_levels.get(stat_key)
-            if keep_best and best is not None:
-                cmp = _level_cmp(current_levels, best, mode, stat_types)
-                if cmp < 0:
-                    return ClaimResult(reject_reason=RejectReason.WORSE_LEVEL)
-                if cmp == 0:
-                    skip = self.equal_skips.get(stat_key, 0)
-                    if skip > 0:
-                        self.equal_skips[stat_key] = skip - 1
-                        return ClaimResult()
-            self.treasure_counts[stat_key] = count + 1
-            best = self.best_levels.get(stat_key)
-            if best is None or _level_cmp(current_levels, best, mode, stat_types) > 0:
-                self.best_levels[stat_key] = current_levels
-            return ClaimResult(accepted_weapon_id=None, updated_levels={})
+            if keep_best and count < limit:
+                return ClaimResult(reject_reason=RejectReason.WORSE_LEVEL)
+            logger.debug(f"[数量上限] 属性组合 [{stat_label}] 已达上限 {count}/{limit}")
+            return ClaimResult(
+                reject_reason=RejectReason.LIMIT,
+                current_count=count,
+            )
 
         weapon_ids = _order_candidate_ids(matched_weapon_ids, weapon_priority_order)
 

--- a/src/endfield_essence_recognizer/core/scanner/evaluate.py
+++ b/src/endfield_essence_recognizer/core/scanner/evaluate.py
@@ -24,6 +24,14 @@ _WEIGHTS_AFFIX_12 = tuple(
 )  # 索引 = 等级（1~6）
 _WEIGHTS_AFFIX_3 = tuple(accumulate((0, 0, 1 / 0.109, 1 / 0.042)))  # 索引 = 等级（1~3）
 
+# ── 词条的语义顺序 ──
+# 与武器的 stat1/stat2/stat3、profile 的 affix1/affix2/affix3 保持一致
+_SEMANTIC_ORDER: tuple[StatType, ...] = (
+    StatType.ATTRIBUTE,
+    StatType.SECONDARY,
+    StatType.SKILL,
+)
+
 
 def _grease_sum(
     levels: tuple[int, int, int], stat_types: list[StatType | None]
@@ -117,6 +125,54 @@ def compare_levels(
         1（当前更优）/ 0（相等）/ -1（当前更差）
     """
     return _level_cmp(current, existing, mode, stat_types)
+
+
+def _normalize_by_stat_type(
+    stats: list[str | None],
+    stat_types: list[StatType | None],
+    levels: list[int | None],
+) -> tuple[tuple[str | None, ...], list[StatType | None], tuple[int, int, int]]:
+    """把识别位置顺序的词条三元组重排为语义顺序（属性、副属性、技能）。
+
+    识别层按屏幕 ROI 位置 0/1/2 产出 stats/stat_types/levels，位置顺序不保证
+    等于语义顺序；而武器的 stat1/2/3 与 profile 的 affix1/2/3 均按语义顺序存储。
+    不归一化时，同一属性组合的基质会因词条显示顺序不同被算作不同分组各占名额，
+    等级比较与落盘也会错位。
+
+    语义类型未识别（None）或重复的位置，按原相对顺序补入剩余空槽。
+
+    Args:
+        stats: 按识别位置排列的属性 ID 列表。
+        stat_types: 按识别位置排列的语义类型列表。
+        levels: 按识别位置排列的等级列表（None 视作 1 级）。
+
+    Returns:
+        (语义顺序的属性组合 key, 语义顺序的类型列表, 语义顺序的等级元组)。
+    """
+    slots: list[int | None] = [None] * len(_SEMANTIC_ORDER)
+    leftovers: list[int] = []
+    for index, stat_type in enumerate(stat_types):
+        slot = (
+            _SEMANTIC_ORDER.index(stat_type) if stat_type in _SEMANTIC_ORDER else None
+        )
+        if slot is None or slots[slot] is not None:
+            leftovers.append(index)
+        else:
+            slots[slot] = index
+
+    # 类型未识别或重复的位置，按原顺序补入剩余空槽
+    order: list[int] = []
+    for slot_index in slots:
+        order.append(leftovers.pop(0) if slot_index is None else slot_index)
+
+    stat_key = tuple(stats[i] for i in order)
+    ordered_types = [stat_types[i] for i in order]
+    ordered_levels = (
+        levels[order[0]] or 1,
+        levels[order[1]] or 1,
+        levels[order[2]] or 1,
+    )
+    return stat_key, ordered_types, ordered_levels
 
 
 def _order_candidate_ids(

--- a/tests/unit/core/scanner/test_claimer.py
+++ b/tests/unit/core/scanner/test_claimer.py
@@ -263,6 +263,80 @@ class TestClaimByMatrix:
         assert result.reject_reason is None
 
 
+class TestClaimUnmatchedHighLevel:
+    """不匹配任何已实装武器的高等级宝藏基质（按属性组合分组认领）。"""
+
+    @pytest.fixture
+    def high_level_settings(self, default_settings):
+        default_settings.high_level_treasure_enabled = True
+        default_settings.same_type_treasure_limit_enabled = True
+        default_settings.same_type_treasure_limit = 1
+        default_settings.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        default_settings.same_type_keep_best = True
+        default_settings.same_type_keep_best_mode = KeepBestMode.WEIGHTED_SUM
+        return default_settings
+
+    def _make_essence(self, levels, stats=None, stat_types=None) -> EssenceData:
+        return EssenceData(
+            stats=stats or ["A", "B", "C"],
+            stat_types=stat_types
+            or [StatType.ATTRIBUTE, StatType.SECONDARY, StatType.SKILL],
+            levels=levels,
+            rarity=RarityLabel.FIVE,
+            abandon_label=AbandonStatusLabel.NOT_ABANDONED,
+            lock_label=LockStatusLabel.NOT_LOCKED,
+        )
+
+    def _claim(self, ctx, essence, settings, static_data):
+        classification = classify_essence(essence, settings, static_data)
+        assert classification.quality == EssenceQuality.TREASURE
+        return ctx.claim(
+            classification, essence, settings, static_game_data=static_data
+        )
+
+    def test_better_level_replaces_after_limit_reached(
+        self, mock_static_game_data, high_level_settings, claim_context
+    ):
+        """达到数量上限后，更优基质仍应按留大弃小替换（上游 issue #199）。"""
+        first = self._claim(
+            claim_context,
+            self._make_essence([3, 1, 1]),
+            high_level_settings,
+            mock_static_game_data,
+        )
+        second = self._claim(
+            claim_context,
+            self._make_essence([4, 1, 1]),
+            high_level_settings,
+            mock_static_game_data,
+        )
+
+        assert first.reject_reason is None
+        assert second.reject_reason is None
+        assert claim_context.best_levels[("A", "B", "C")] == (4, 1, 1)
+        # 替换语义：不额外占用名额
+        assert claim_context.treasure_counts[("A", "B", "C")] == 1
+
+    def test_worse_level_rejected_after_limit_reached(
+        self, mock_static_game_data, high_level_settings, claim_context
+    ):
+        """扫描顺序反转：更差基质仍判为养成材料，保留的始终是更优的那枚。"""
+        self._claim(
+            claim_context,
+            self._make_essence([4, 1, 1]),
+            high_level_settings,
+            mock_static_game_data,
+        )
+        second = self._claim(
+            claim_context,
+            self._make_essence([3, 1, 1]),
+            high_level_settings,
+            mock_static_game_data,
+        )
+
+        assert second.reject_reason is RejectReason.LIMIT
+        assert claim_context.best_levels[("A", "B", "C")] == (4, 1, 1)
+        assert claim_context.treasure_counts[("A", "B", "C")] == 1
 class TestClaimNonTreasure:
     """非宝藏基质不认领。"""
 

--- a/tests/unit/core/scanner/test_claimer.py
+++ b/tests/unit/core/scanner/test_claimer.py
@@ -337,6 +337,32 @@ class TestClaimUnmatchedHighLevel:
         assert second.reject_reason is RejectReason.LIMIT
         assert claim_context.best_levels[("A", "B", "C")] == (4, 1, 1)
         assert claim_context.treasure_counts[("A", "B", "C")] == 1
+
+    def test_stat_order_normalized_into_same_group(
+        self, mock_static_game_data, high_level_settings, claim_context
+    ):
+        """词条显示顺序不同的同属性组合归入同一分组，不各占名额。"""
+        self._claim(
+            claim_context,
+            self._make_essence([3, 1, 1]),
+            high_level_settings,
+            mock_static_game_data,
+        )
+        # 同一属性组合，识别位置顺序为技能、属性、副属性
+        reordered = self._make_essence(
+            [1, 4, 1],
+            stats=["C", "A", "B"],
+            stat_types=[StatType.SKILL, StatType.ATTRIBUTE, StatType.SECONDARY],
+        )
+        second = self._claim(
+            claim_context, reordered, high_level_settings, mock_static_game_data
+        )
+
+        assert list(claim_context.treasure_counts) == [("A", "B", "C")]
+        assert second.reject_reason is None
+        assert claim_context.best_levels[("A", "B", "C")] == (4, 1, 1)
+
+
 class TestClaimNonTreasure:
     """非宝藏基质不认领。"""
 


### PR DESCRIPTION
修复两个影响宝藏基质认领逻辑的问题（closes #199）：

1. 留大弃小优先于数量上限判定

此前无匹配武器的认领路径先检查数量上限，再检查留大弃小。导致达到上限后，更优基质无法替换已保存的那一枚，反而被错误丢弃。

调整为先判断留大弃小（替换语义，不增计数），再走数量上限新增逻辑。

2. 按语义类型归一化词条顺序后再分组

识别层按屏幕 ROI 位置产出词条三元组，位置顺序不保证等于语义顺序（属性/副属性/技能）。同一属性组合因词条显示顺序不同被算作不同分组，各自占名额，等级比较也会错位。

新增 _normalize_by_stat_type 将词条重排为语义顺序后再参与分组和比较。

测试覆盖：
- 达到上限后更优基质仍可替换
- 更差基质在上限后被正确拒绝
- 词条顺序不同的同属性组合归入同一分组