### PR TITLE
feat: 宝藏基质导出为图片

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ logs/
 # screenshots by the server
 screenshots/
 
+# 宝藏基质导出的图片
+exports/
+
 # local app settings
 config.json
 .env

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -144,7 +144,7 @@ import {
   getStatsForWeapon,
   toCustomStatId,
 } from '@/utils/gameData/weapon'
-import { renderMatrixExport } from '@/utils/matrixExport'
+import { renderMatrixExport, toPngBlob } from '@/utils/matrixExport'
 
 const open = defineModel<boolean>({ default: false })
 
@@ -470,7 +470,8 @@ async function copyToClipboard() {
 
   copying.value = true
   try {
-    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+    // 剪贴板只吃 PNG，导出图是 WebP，这里现场转一份
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': await toPngBlob(blob) })])
     toast.success('已复制到剪贴板')
   } catch (error) {
     toast.reportError('复制到剪贴板失败', error)

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -129,9 +129,8 @@
 
 <script lang="ts" setup>
 import type { TreasureMatrixEntry } from '@/composables/useProfiles'
-import type { ExportCard, ExportTheme } from '@/utils/matrixExport'
+import type { ExportCard } from '@/utils/matrixExport'
 import { computed, onUnmounted, ref, watch } from 'vue'
-import { useTheme } from 'vuetify'
 import { useCustomStats } from '@/composables/useCustomStats'
 import { useProfiles } from '@/composables/useProfiles'
 import { useToast } from '@/composables/useToast'
@@ -150,7 +149,6 @@ import { renderMatrixExport } from '@/utils/matrixExport'
 const open = defineModel<boolean>({ default: false })
 
 const toast = useToast()
-const theme = useTheme()
 const { activeProfileName, treasureMatrix } = useProfiles()
 const { customStats } = useCustomStats()
 const { isCustomEntry, isWeaponMaxed, isWeaponOwned } = useWeaponStats()
@@ -390,24 +388,6 @@ const customCards = computed<ExportCard[]>(() => [
 
 const totalCount = computed(() => weaponCards.value.length + customCards.value.length)
 
-/**
- * 从当前 Vuetify 主题取出绘制需要的颜色，canvas 读不到 CSS 变量。
- *
- * 必须走 computedThemes 而不是 current：v-app 会调用 provideTheme，
- * 而它把 current 指向未经计算的原始 themes（vuetify theme.js:375），
- * 那里没有自动生成的 on-* 系列颜色，取出来会是 undefined。
- */
-function currentTheme(): ExportTheme {
-  const colors = theme.computedThemes.value[theme.name.value]!.colors
-  return {
-    primary: colors.primary!,
-    onPrimary: colors['on-primary']!,
-    background: colors.background!,
-    surface: colors.surface!,
-    onSurface: colors['on-surface']!,
-  }
-}
-
 function releasePreview() {
   if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
   previewUrl.value = null
@@ -443,8 +423,8 @@ async function regenerate() {
       weapons: weaponCards.value,
       customs: customCards.value,
       title: `${activeProfileName.value} · 宝藏基质`,
-      subtitle: `${new Date().toLocaleString('zh-CN')} · 共 ${totalCount.value} 项`,
-      theme: currentTheme(),
+      // 条目数由绘制模块自己从卡片数量算，这里只给归档时间
+      subtitle: new Date().toLocaleString('zh-CN'),
     })
 
     // 期间又触发了新一轮渲染，丢弃这次的结果

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -10,7 +10,13 @@
         <!-- 导出范围：与页面顶部的筛选相互独立，避免互相污染 -->
         <div class="d-flex align-center gap-2 mb-2">
           <span class="text-body-2 text-medium-emphasis">导出星级：</span>
-          <v-chip-group v-model="selectedRarities" column multiple>
+          <!-- 单向绑定：勾选「自定义」时要先弹确认，双向绑定拦不住这次点击 -->
+          <v-chip-group
+            column
+            :model-value="selectedRarities"
+            multiple
+            @update:model-value="onRaritySelectionChange"
+          >
             <v-chip color="primary" filter size="small" value="3" variant="outlined"> 3★ </v-chip>
             <v-chip color="primary" filter size="small" value="4" variant="outlined"> 4★ </v-chip>
             <v-chip color="primary" filter size="small" value="5" variant="outlined"> 5★ </v-chip>
@@ -30,6 +36,14 @@
             label="包含满级武器（6/6/3）"
           />
           <v-switch
+            v-model="includeUnowned"
+            color="primary"
+            density="compact"
+            :disabled="onlyIncludedInCalculation"
+            hide-details
+            label="未获得的武器/基质"
+          />
+          <v-switch
             v-model="onlyIncludedInCalculation"
             color="primary"
             density="compact"
@@ -45,7 +59,8 @@
           />
         </div>
         <div class="text-caption text-medium-emphasis mb-4">
-          角标来自本次运行的扫描结果，重启后清零；自定义基质无对应数据。
+          未获得的条目按 0/6·0/6·0/3
+          置灰展示；角标来自本次运行的扫描结果，重启后清零，自定义基质无对应数据。
         </div>
 
         <v-alert v-if="totalCount === 0" border="start" type="warning" variant="tonal">
@@ -90,6 +105,26 @@
       </v-card-actions>
     </v-card>
   </v-dialog>
+
+  <!-- 自定义基质可能有几百枚，一次全画会卡住界面，开启前先确认 -->
+  <v-dialog v-model="showCustomConfirm" max-width="460">
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2" color="warning">mdi-alert-outline</v-icon>
+        加入自定义基质
+      </v-card-title>
+      <v-card-text>
+        当前配置中有 {{ customStats.length }} 枚自定义基质。
+        <br />
+        全部绘制会长时间占用主线程，数量多时界面可能明显卡顿甚至短暂无响应。确认加入导出？
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn variant="text" @click="showCustomConfirm = false">取消</v-btn>
+        <v-btn color="warning" variant="flat" @click="confirmIncludeCustom">确认加入</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts" setup>
@@ -108,6 +143,7 @@ import {
   findCustomStat,
   getGemTagName,
   getStatsForWeapon,
+  toCustomStatId,
 } from '@/utils/gameData/weapon'
 import { renderMatrixExport } from '@/utils/matrixExport'
 
@@ -117,18 +153,27 @@ const toast = useToast()
 const theme = useTheme()
 const { activeProfileName, treasureMatrix } = useProfiles()
 const { customStats } = useCustomStats()
-const { isCustomEntry, isWeaponMaxed, getWeaponPriority } = useWeaponStats()
-const { weaponsMap, matrixIcons } = useStaticData()
+const { isCustomEntry, isWeaponMaxed, isWeaponOwned } = useWeaponStats()
+const { weaponsMap, weaponTypes, matrixIcons } = useStaticData()
 
 /** 自定义基质在导出图里按 6★ 处理，与页面筛选口径一致 */
 const CUSTOM_RARITY_KEY = 'custom'
 /** 自定义基质卡片的底部色条 */
 const CUSTOM_TIER_COLOR = '#ff7100'
+/** 未获得条目的词条等级：三条全为 0 */
+const UNOWNED_LEVELS = [0, 0, 0] as const
 
-const selectedRarities = ref<string[]>(['3', '4', '5', '6', CUSTOM_RARITY_KEY])
+// 自定义基质默认不勾选：批量添加之后配置里可能有几百枚，
+// 默认全画出来会让弹窗一打开就卡住。
+const selectedRarities = ref<string[]>(['3', '4', '5', '6'])
 const includeMaxed = ref(true)
+const includeUnowned = ref(true)
 const onlyIncludedInCalculation = ref(false)
 const showBadges = ref(false)
+const showCustomConfirm = ref(false)
+
+/** 等待用户确认时暂存的目标选择，确认后才写回 selectedRarities */
+let pendingRarities: string[] = []
 
 const essenceCounts = ref<Record<string, number>>({})
 const previewUrl = ref<string | null>(null)
@@ -196,12 +241,36 @@ function getTraitNames(weaponId: string): string[] {
   return parts
 }
 
-function matchesFilters(entry: TreasureMatrixEntry, rarityKey: string): boolean {
-  if (!selectedRarities.value.includes(rarityKey)) return false
+/**
+ * 星级 chip 的选择变更入口。
+ *
+ * 勾选「自定义」时先弹确认再生效：确认前 selectedRarities 保持不变，
+ * chip 也就不会亮起来，取消/ESC/点遮罩都无需额外回滚。
+ */
+function onRaritySelectionChange(value: unknown) {
+  const next = value as string[]
+  if (next.includes(CUSTOM_RARITY_KEY) && !selectedRarities.value.includes(CUSTOM_RARITY_KEY)) {
+    pendingRarities = next
+    showCustomConfirm.value = true
+    return
+  }
+  selectedRarities.value = next
+}
+
+function confirmIncludeCustom() {
+  selectedRarities.value = pendingRarities
+  showCustomConfirm.value = false
+}
+
+/** 已获得条目要额外过的两个开关；星级筛选在各自的 computed 里判断 */
+function passesToggles(entry: TreasureMatrixEntry): boolean {
   if (!includeMaxed.value && isWeaponMaxed(entry.weapon_id)) return false
   if (onlyIncludedInCalculation.value && entry.include_in_calculation === false) return false
   return true
 }
+
+/** 是否绘制未获得的条目：「仅导出参与计算」开启时它们本就不参与计算，一律排除 */
+const showUnowned = computed(() => includeUnowned.value && !onlyIncludedInCalculation.value)
 
 function toLevels(entry: TreasureMatrixEntry): [number, number, number] {
   return [
@@ -211,42 +280,72 @@ function toLevels(entry: TreasureMatrixEntry): [number, number, number] {
   ]
 }
 
-const weaponCards = computed<ExportCard[]>(() => {
-  const entries = treasureMatrix.value.filter((entry) => {
-    if (isCustomEntry(entry.weapon_id)) return false
-    // 丢弃静态数据里已不存在的武器，避免画出空白卡
-    const weapon = weaponsMap.value.get(entry.weapon_id)
-    if (!weapon) return false
-    return matchesFilters(entry, String(weapon.rarity))
-  })
-
-  return entries
-    .toSorted((a, b) => {
-      const priorityDiff = getWeaponPriority(b.weapon_id) - getWeaponPriority(a.weapon_id)
-      if (priorityDiff !== 0) return priorityDiff
-      const rarityDiff =
-        (weaponsMap.value.get(b.weapon_id)?.rarity ?? 0) -
-        (weaponsMap.value.get(a.weapon_id)?.rarity ?? 0)
-      if (rarityDiff !== 0) return rarityDiff
-      return a.weapon_id.localeCompare(b.weapon_id)
-    })
-    .map((entry) => ({
-      kind: 'weapon' as const,
-      name: weaponsMap.value.get(entry.weapon_id)?.name ?? entry.weapon_name,
-      iconUrl: getItemIconUrl(entry.weapon_id) ?? null,
-      essenceBgUrl: matrixIcons.value.essenceBg,
-      skillIconUrl: resolveSkillIconUrl(entry.weapon_id),
-      tierColor: getItemTierColor(entry.weapon_id).hex(),
-      levels: toLevels(entry),
-      maxed: isWeaponMaxed(entry.weapon_id),
-      badgeCount: showBadges.value ? essenceCounts.value[entry.weapon_id] : undefined,
-      traitNames: getTraitNames(entry.weapon_id),
-    }))
+/**
+ * weapon_id → 所属武器类型的 sortOrder。
+ *
+ * 后端已按 sortOrder 排好（单手剑→双手剑→长柄武器→手铳→施术单元），
+ * 这里仍显式读 sortOrder 而不是数组下标，接口顺序万一变了也不会静默错位。
+ */
+const weaponTypeOrder = computed(() => {
+  const order = new Map<string, number>()
+  for (const weaponType of weaponTypes.value) {
+    for (const weaponId of weaponType.weaponIds) {
+      order.set(weaponId, weaponType.sortOrder)
+    }
+  }
+  return order
 })
 
-const customCards = computed<ExportCard[]>(() =>
-  treasureMatrix.value
-    .filter((entry) => isCustomEntry(entry.weapon_id) && matchesFilters(entry, CUSTOM_RARITY_KEY))
+/**
+ * 内置武器区的卡片。
+ *
+ * 排序：武器类型（单手剑→…→施术单元）→ 稀有度降序（6★→3★）→ id 升序。
+ * 已获得与未获得走同一条序列，未获得的穿插在已获得之间而不是堆在最后。
+ * 只遍历静态数据里的武器，账号里指向已下线 ID 的条目自然被丢弃，避免画出空白卡。
+ */
+const weaponCards = computed<ExportCard[]>(() => {
+  const entryByWeaponId = new Map(
+    treasureMatrix.value.map((entry) => [entry.weapon_id, entry] as const),
+  )
+  const weapons = [...weaponsMap.value.values()].toSorted((a, b) => {
+    // 不属于任何类型的武器（类型数据缺失时）沉到最末尾
+    const typeA = weaponTypeOrder.value.get(a.id) ?? Number.POSITIVE_INFINITY
+    const typeB = weaponTypeOrder.value.get(b.id) ?? Number.POSITIVE_INFINITY
+    if (typeA !== typeB) return typeA - typeB
+    if (a.rarity !== b.rarity) return b.rarity - a.rarity
+    return a.id.localeCompare(b.id)
+  })
+
+  const cards: ExportCard[] = []
+  for (const weapon of weapons) {
+    if (!selectedRarities.value.includes(String(weapon.rarity))) continue
+
+    const entry = entryByWeaponId.get(weapon.id)
+    if (entry ? !passesToggles(entry) : !showUnowned.value) continue
+
+    cards.push({
+      kind: 'weapon',
+      name: weapon.name,
+      nameRuby: '★'.repeat(weapon.rarity),
+      iconUrl: getItemIconUrl(weapon.id) ?? null,
+      essenceBgUrl: matrixIcons.value.essenceBg,
+      skillIconUrl: resolveSkillIconUrl(weapon.id),
+      tierColor: getItemTierColor(weapon.id).hex(),
+      levels: entry ? toLevels(entry) : UNOWNED_LEVELS,
+      maxed: isWeaponMaxed(weapon.id),
+      // 未获得的武器不画角标：扫到的基质还没有落到具体武器上
+      badgeCount: entry && showBadges.value ? essenceCounts.value[weapon.id] : undefined,
+      traitNames: getTraitNames(weapon.id),
+      dimmed: entry === undefined,
+    })
+  }
+  return cards
+})
+
+const ownedCustomCards = computed<ExportCard[]>(() => {
+  if (!selectedRarities.value.includes(CUSTOM_RARITY_KEY)) return []
+  return treasureMatrix.value
+    .filter((entry) => isCustomEntry(entry.weapon_id) && passesToggles(entry))
     .map((entry) => ({
       kind: 'custom' as const,
       name: resolveCustomName(entry),
@@ -257,8 +356,37 @@ const customCards = computed<ExportCard[]>(() =>
       levels: toLevels(entry),
       maxed: isWeaponMaxed(entry.weapon_id),
       traitNames: getTraitNames(entry.weapon_id),
-    })),
-)
+    }))
+})
+
+/** 未获得的自定义基质：配置里有、但账号里没写入 treasure_matrix 的那些 */
+const unownedCustomCards = computed<ExportCard[]>(() => {
+  if (!selectedRarities.value.includes(CUSTOM_RARITY_KEY) || !showUnowned.value) return []
+
+  return customStats.value
+    .map((stat, index) => ({
+      weaponId: toCustomStatId(stat),
+      name: stat.name || fallbackCustomStatName(index),
+    }))
+    .filter((item) => !isWeaponOwned(item.weaponId))
+    .map((item) => ({
+      kind: 'custom' as const,
+      name: item.name,
+      iconUrl: null,
+      essenceBgUrl: matrixIcons.value.essenceBg,
+      skillIconUrl: resolveSkillIconUrl(item.weaponId),
+      tierColor: CUSTOM_TIER_COLOR,
+      levels: UNOWNED_LEVELS,
+      maxed: false,
+      traitNames: getTraitNames(item.weaponId),
+      dimmed: true,
+    }))
+})
+
+const customCards = computed<ExportCard[]>(() => [
+  ...ownedCustomCards.value,
+  ...unownedCustomCards.value,
+])
 
 const totalCount = computed(() => weaponCards.value.length + customCards.value.length)
 
@@ -419,7 +547,14 @@ watch(open, (opened) => {
 })
 
 watch(
-  [selectedRarities, includeMaxed, onlyIncludedInCalculation, showBadges, treasureMatrix],
+  [
+    selectedRarities,
+    includeMaxed,
+    includeUnowned,
+    onlyIncludedInCalculation,
+    showBadges,
+    treasureMatrix,
+  ],
   () => {
     if (open.value) scheduleRegenerate()
   },

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -1,0 +1,403 @@
+<template>
+  <v-dialog v-model="open" max-width="960" scrollable>
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2">mdi-image-outline</v-icon>
+        导出宝藏基质图片
+      </v-card-title>
+
+      <v-card-text>
+        <!-- 导出范围：与页面顶部的筛选相互独立，避免互相污染 -->
+        <div class="d-flex align-center gap-2 mb-2">
+          <span class="text-body-2 text-medium-emphasis">导出星级：</span>
+          <v-chip-group v-model="selectedRarities" column multiple>
+            <v-chip color="primary" filter size="small" value="3" variant="outlined"> 3★ </v-chip>
+            <v-chip color="primary" filter size="small" value="4" variant="outlined"> 4★ </v-chip>
+            <v-chip color="primary" filter size="small" value="5" variant="outlined"> 5★ </v-chip>
+            <v-chip color="primary" filter size="small" value="6" variant="outlined"> 6★ </v-chip>
+            <v-chip color="primary" filter size="small" value="custom" variant="outlined">
+              自定义
+            </v-chip>
+          </v-chip-group>
+        </div>
+
+        <div class="d-flex flex-wrap align-center ga-4 mb-1">
+          <v-switch
+            v-model="includeMaxed"
+            color="primary"
+            density="compact"
+            hide-details
+            label="包含满级武器（6/6/3）"
+          />
+          <v-switch
+            v-model="onlyIncludedInCalculation"
+            color="primary"
+            density="compact"
+            hide-details
+            label="仅导出参与计算的条目"
+          />
+          <v-switch
+            v-model="showBadges"
+            color="primary"
+            density="compact"
+            hide-details
+            label="显示扫描数量角标"
+          />
+        </div>
+        <div class="text-caption text-medium-emphasis mb-4">
+          角标来自本次运行的扫描结果，重启后清零；自定义基质无对应数据。
+        </div>
+
+        <v-alert v-if="totalCount === 0" border="start" type="warning" variant="tonal">
+          当前筛选下没有可导出的条目。
+        </v-alert>
+
+        <template v-else>
+          <div class="text-body-2 text-medium-emphasis mb-2">
+            将导出 {{ totalCount }} 项（内置 {{ weaponCards.length }} / 自定义
+            {{ customCards.length }}）
+            <template v-if="renderInfo">
+              · {{ renderInfo.width }} × {{ renderInfo.height }} @{{ renderInfo.scale }}x ·
+              {{ renderInfo.sizeText }}
+            </template>
+          </div>
+
+          <v-progress-linear v-if="rendering" color="primary" indeterminate />
+          <img v-if="previewUrl" alt="宝藏基质导出预览" class="export-preview" :src="previewUrl" />
+        </template>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn variant="text" @click="open = false">关闭</v-btn>
+        <v-btn
+          :disabled="!previewUrl || rendering"
+          :loading="copying"
+          variant="tonal"
+          @click="copyToClipboard"
+        >
+          复制到剪贴板
+        </v-btn>
+        <v-btn
+          color="primary"
+          :disabled="!previewUrl || rendering"
+          :loading="saving"
+          variant="flat"
+          @click="saveToDisk"
+        >
+          保存并打开文件夹
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import type { TreasureMatrixEntry } from '@/composables/useProfiles'
+import type { ExportCard, ExportTheme } from '@/utils/matrixExport'
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { useTheme } from 'vuetify'
+import { useCustomStats } from '@/composables/useCustomStats'
+import { useProfiles } from '@/composables/useProfiles'
+import { useToast } from '@/composables/useToast'
+import { AFFIX_MAX_LEVEL, useWeaponStats } from '@/composables/useWeaponStats'
+import { getItemIconUrl, getItemTierColor } from '@/utils/gameData/item'
+import { useStaticData } from '@/utils/gameData/staticData'
+import { fallbackCustomStatName, findCustomStat } from '@/utils/gameData/weapon'
+import { renderMatrixExport } from '@/utils/matrixExport'
+
+const open = defineModel<boolean>({ default: false })
+
+const toast = useToast()
+const theme = useTheme()
+const { activeProfileName, treasureMatrix } = useProfiles()
+const { customStats } = useCustomStats()
+const { isCustomEntry, isWeaponMaxed, getWeaponPriority } = useWeaponStats()
+const { weaponsMap, matrixIcons } = useStaticData()
+
+/** 自定义基质在导出图里按 6★ 处理，与页面筛选口径一致 */
+const CUSTOM_RARITY_KEY = 'custom'
+/** 自定义基质卡片的底部色条 */
+const CUSTOM_TIER_COLOR = '#ff7100'
+
+const selectedRarities = ref<string[]>(['3', '4', '5', '6', CUSTOM_RARITY_KEY])
+const includeMaxed = ref(true)
+const onlyIncludedInCalculation = ref(false)
+const showBadges = ref(false)
+
+const essenceCounts = ref<Record<string, number>>({})
+const previewUrl = ref<string | null>(null)
+const previewBlob = ref<Blob | null>(null)
+const renderInfo = ref<{
+  width: number
+  height: number
+  scale: number
+  sizeText: string
+} | null>(null)
+const rendering = ref(false)
+const copying = ref(false)
+const saving = ref(false)
+
+let renderToken = 0
+let redrawTimer: ReturnType<typeof setTimeout> | undefined
+
+/**
+ * 解析条目的技能属性图标地址。
+ *
+ * 自定义基质从配置里取技能词条，内置武器从静态数据取；
+ * 两者都没有匹配时回退到默认基质图标。
+ */
+function resolveSkillIconUrl(weaponId: string): string | null {
+  const fallback = matrixIcons.value.defaultIcon || null
+  const skillStatId = isCustomEntry(weaponId)
+    ? findCustomStat(weaponId, customStats.value)?.stat.skill
+    : weaponsMap.value.get(weaponId)?.skillStatId
+  if (!skillStatId) return fallback
+  return matrixIcons.value.skills[skillStatId] || fallback
+}
+
+/** 自定义基质的显示名，配置里没填时用兜底名 */
+function resolveCustomName(entry: TreasureMatrixEntry): string {
+  const found = findCustomStat(entry.weapon_id, customStats.value)
+  if (!found) return entry.weapon_name || entry.weapon_id
+  return found.stat.name || fallbackCustomStatName(found.index)
+}
+
+function matchesFilters(entry: TreasureMatrixEntry, rarityKey: string): boolean {
+  if (!selectedRarities.value.includes(rarityKey)) return false
+  if (!includeMaxed.value && isWeaponMaxed(entry.weapon_id)) return false
+  if (onlyIncludedInCalculation.value && entry.include_in_calculation === false) return false
+  return true
+}
+
+function toLevels(entry: TreasureMatrixEntry): [number, number, number] {
+  return [
+    Math.min(entry.affix1_level, AFFIX_MAX_LEVEL[0]),
+    Math.min(entry.affix2_level, AFFIX_MAX_LEVEL[1]),
+    Math.min(entry.affix3_level, AFFIX_MAX_LEVEL[2]),
+  ]
+}
+
+const weaponCards = computed<ExportCard[]>(() => {
+  const entries = treasureMatrix.value.filter((entry) => {
+    if (isCustomEntry(entry.weapon_id)) return false
+    // 丢弃静态数据里已不存在的武器，避免画出空白卡
+    const weapon = weaponsMap.value.get(entry.weapon_id)
+    if (!weapon) return false
+    return matchesFilters(entry, String(weapon.rarity))
+  })
+
+  return entries
+    .toSorted((a, b) => {
+      const priorityDiff = getWeaponPriority(b.weapon_id) - getWeaponPriority(a.weapon_id)
+      if (priorityDiff !== 0) return priorityDiff
+      const rarityDiff =
+        (weaponsMap.value.get(b.weapon_id)?.rarity ?? 0) -
+        (weaponsMap.value.get(a.weapon_id)?.rarity ?? 0)
+      if (rarityDiff !== 0) return rarityDiff
+      return a.weapon_id.localeCompare(b.weapon_id)
+    })
+    .map((entry) => ({
+      kind: 'weapon' as const,
+      name: weaponsMap.value.get(entry.weapon_id)?.name ?? entry.weapon_name,
+      iconUrl: getItemIconUrl(entry.weapon_id) ?? null,
+      essenceBgUrl: matrixIcons.value.essenceBg,
+      skillIconUrl: resolveSkillIconUrl(entry.weapon_id),
+      tierColor: getItemTierColor(entry.weapon_id).hex(),
+      levels: toLevels(entry),
+      maxed: isWeaponMaxed(entry.weapon_id),
+      badgeCount: showBadges.value ? essenceCounts.value[entry.weapon_id] : undefined,
+    }))
+})
+
+const customCards = computed<ExportCard[]>(() =>
+  treasureMatrix.value
+    .filter((entry) => isCustomEntry(entry.weapon_id) && matchesFilters(entry, CUSTOM_RARITY_KEY))
+    .map((entry) => ({
+      kind: 'custom' as const,
+      name: resolveCustomName(entry),
+      iconUrl: null,
+      essenceBgUrl: matrixIcons.value.essenceBg,
+      skillIconUrl: resolveSkillIconUrl(entry.weapon_id),
+      tierColor: CUSTOM_TIER_COLOR,
+      levels: toLevels(entry),
+      maxed: isWeaponMaxed(entry.weapon_id),
+    })),
+)
+
+const totalCount = computed(() => weaponCards.value.length + customCards.value.length)
+
+/** 从当前 Vuetify 主题取出绘制需要的颜色，canvas 读不到 CSS 变量 */
+function currentTheme(): ExportTheme {
+  const colors = theme.current.value.colors
+  return {
+    primary: colors.primary,
+    onPrimary: colors['on-primary'],
+    background: colors.background,
+    surface: colors.surface,
+    onSurface: colors['on-surface'],
+  }
+}
+
+function releasePreview() {
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
+  previewUrl.value = null
+  previewBlob.value = null
+  renderInfo.value = null
+}
+
+/** 拉取扫描数量；失败不阻断导出，角标退化为关闭 */
+async function loadEssenceCounts() {
+  try {
+    const res = await fetch('/api/weapon_essence_counts')
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+    const result = await res.json()
+    essenceCounts.value = result.counts ?? {}
+  } catch (error) {
+    essenceCounts.value = {}
+    toast.reportError('获取扫描数量失败', error)
+  }
+  // 有数据才默认打开，否则用户会看到一个"打开了却什么也没变"的开关
+  showBadges.value = Object.values(essenceCounts.value).some((count) => count > 0)
+}
+
+async function regenerate() {
+  if (totalCount.value === 0) {
+    releasePreview()
+    return
+  }
+
+  const token = ++renderToken
+  rendering.value = true
+  try {
+    const result = await renderMatrixExport({
+      weapons: weaponCards.value,
+      customs: customCards.value,
+      title: `${activeProfileName.value} · 宝藏基质`,
+      subtitle: `${new Date().toLocaleString('zh-CN')} · 共 ${totalCount.value} 项`,
+      theme: currentTheme(),
+    })
+
+    // 期间又触发了新一轮渲染，丢弃这次的结果
+    if (token !== renderToken) {
+      URL.revokeObjectURL(result.objectUrl)
+      return
+    }
+
+    releasePreview()
+    previewUrl.value = result.objectUrl
+    previewBlob.value = result.blob
+    renderInfo.value = {
+      width: result.width,
+      height: result.height,
+      scale: result.scale,
+      sizeText: `${Math.round(result.blob.size / 1024)} KB`,
+    }
+    if (result.missingImages > 0) {
+      toast.warning(`${result.missingImages} 个图标加载失败，已用占位图代替`)
+    }
+  } catch (error) {
+    if (token === renderToken) releasePreview()
+    toast.reportError('生成导出图片失败', error)
+  } finally {
+    if (token === renderToken) rendering.value = false
+  }
+}
+
+/** 防抖重绘：筛选项连点时只跑最后一次 */
+function scheduleRegenerate() {
+  clearTimeout(redrawTimer)
+  redrawTimer = setTimeout(() => void regenerate(), 200)
+}
+
+async function copyToClipboard() {
+  const blob = previewBlob.value
+  if (!blob) return
+
+  if (typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) {
+    toast.error('当前环境不支持写入剪贴板，请改用「保存并打开文件夹」')
+    return
+  }
+
+  copying.value = true
+  try {
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+    toast.success('已复制到剪贴板')
+  } catch (error) {
+    toast.reportError('复制到剪贴板失败', error)
+  } finally {
+    copying.value = false
+  }
+}
+
+/** 把 Blob 转成不含前缀的 base64；大图不能用 fromCharCode 展开，会爆调用栈 */
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => {
+      const dataUrl = reader.result as string
+      resolve(dataUrl.slice(dataUrl.indexOf(',') + 1))
+    })
+    reader.addEventListener('error', () => reject(reader.error))
+    reader.readAsDataURL(blob)
+  })
+}
+
+async function saveToDisk() {
+  const blob = previewBlob.value
+  if (!blob) return
+
+  saving.value = true
+  try {
+    const res = await fetch('/api/export/treasure_matrix', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        image_base64: await blobToBase64(blob),
+        open_folder: true,
+      }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+    const data = await res.json()
+    if (!data.success) throw new Error(data.message)
+    toast.success(`已保存到 ${data.file_path}`)
+  } catch (error) {
+    toast.reportError('保存导出图片失败', error)
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(open, (opened) => {
+  if (opened) {
+    void loadEssenceCounts().then(regenerate)
+  } else {
+    clearTimeout(redrawTimer)
+    releasePreview()
+  }
+})
+
+watch(
+  [selectedRarities, includeMaxed, onlyIncludedInCalculation, showBadges, treasureMatrix],
+  () => {
+    if (open.value) scheduleRegenerate()
+  },
+  { deep: true },
+)
+
+onUnmounted(() => {
+  clearTimeout(redrawTimer)
+  releasePreview()
+})
+</script>
+
+<style lang="scss" scoped>
+.export-preview {
+  display: block;
+  width: 100%;
+  max-height: 52vh;
+  object-fit: contain;
+  border: 1px solid rgba(var(--v-border-color), 0.12);
+  border-radius: 8px;
+}
+</style>

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -227,15 +227,21 @@ const customCards = computed<ExportCard[]>(() =>
 
 const totalCount = computed(() => weaponCards.value.length + customCards.value.length)
 
-/** 从当前 Vuetify 主题取出绘制需要的颜色，canvas 读不到 CSS 变量 */
+/**
+ * 从当前 Vuetify 主题取出绘制需要的颜色，canvas 读不到 CSS 变量。
+ *
+ * 必须走 computedThemes 而不是 current：v-app 会调用 provideTheme，
+ * 而它把 current 指向未经计算的原始 themes（vuetify theme.js:375），
+ * 那里没有自动生成的 on-* 系列颜色，取出来会是 undefined。
+ */
 function currentTheme(): ExportTheme {
-  const colors = theme.current.value.colors
+  const colors = theme.computedThemes.value[theme.name.value]!.colors
   return {
-    primary: colors.primary,
-    onPrimary: colors['on-primary'],
-    background: colors.background,
-    surface: colors.surface,
-    onSurface: colors['on-surface'],
+    primary: colors.primary!,
+    onPrimary: colors['on-primary']!,
+    background: colors.background!,
+    surface: colors.surface!,
+    onSurface: colors['on-surface']!,
   }
 }
 

--- a/frontend/src/components/MatrixExportDialog.vue
+++ b/frontend/src/components/MatrixExportDialog.vue
@@ -103,7 +103,12 @@ import { useToast } from '@/composables/useToast'
 import { AFFIX_MAX_LEVEL, useWeaponStats } from '@/composables/useWeaponStats'
 import { getItemIconUrl, getItemTierColor } from '@/utils/gameData/item'
 import { useStaticData } from '@/utils/gameData/staticData'
-import { fallbackCustomStatName, findCustomStat } from '@/utils/gameData/weapon'
+import {
+  fallbackCustomStatName,
+  findCustomStat,
+  getGemTagName,
+  getStatsForWeapon,
+} from '@/utils/gameData/weapon'
 import { renderMatrixExport } from '@/utils/matrixExport'
 
 const open = defineModel<boolean>({ default: false })
@@ -163,6 +168,34 @@ function resolveCustomName(entry: TreasureMatrixEntry): string {
   return found.stat.name || fallbackCustomStatName(found.index)
 }
 
+/**
+ * 获取武器的三词条中文名。
+ *
+ * 自定义基质从配置里读取，内置武器从静态数据读取；
+ * 返回 ["攻击", "终结技充能效率", "巧技"] 这样的数组。
+ */
+function getTraitNames(weaponId: string): string[] {
+  // 自定义基质：从配置中读取
+  if (isCustomEntry(weaponId)) {
+    const found = findCustomStat(weaponId, customStats.value)
+    if (!found) return []
+    const stat = found.stat
+    const parts: string[] = []
+    if (stat.attribute) parts.push(getGemTagName(stat.attribute))
+    if (stat.secondary) parts.push(getGemTagName(stat.secondary))
+    if (stat.skill) parts.push(getGemTagName(stat.skill))
+    return parts
+  }
+
+  // 内置武器：从静态数据读取
+  const stats = getStatsForWeapon(weaponId)
+  const parts: string[] = []
+  if (stats.attribute) parts.push(getGemTagName(stats.attribute))
+  if (stats.secondary) parts.push(getGemTagName(stats.secondary))
+  if (stats.skill) parts.push(getGemTagName(stats.skill))
+  return parts
+}
+
 function matchesFilters(entry: TreasureMatrixEntry, rarityKey: string): boolean {
   if (!selectedRarities.value.includes(rarityKey)) return false
   if (!includeMaxed.value && isWeaponMaxed(entry.weapon_id)) return false
@@ -207,6 +240,7 @@ const weaponCards = computed<ExportCard[]>(() => {
       levels: toLevels(entry),
       maxed: isWeaponMaxed(entry.weapon_id),
       badgeCount: showBadges.value ? essenceCounts.value[entry.weapon_id] : undefined,
+      traitNames: getTraitNames(entry.weapon_id),
     }))
 })
 
@@ -222,6 +256,7 @@ const customCards = computed<ExportCard[]>(() =>
       tierColor: CUSTOM_TIER_COLOR,
       levels: toLevels(entry),
       maxed: isWeaponMaxed(entry.weapon_id),
+      traitNames: getTraitNames(entry.weapon_id),
     })),
 )
 

--- a/frontend/src/components/WeaponOverview.vue
+++ b/frontend/src/components/WeaponOverview.vue
@@ -53,6 +53,15 @@
         >
           {{ switchModeLabels[switchDisplayMode] }}
         </v-btn>
+        <v-btn
+          color="secondary"
+          prepend-icon="mdi-image-outline"
+          size="small"
+          variant="tonal"
+          @click="showExportDialog = true"
+        >
+          导出为图片
+        </v-btn>
       </div>
 
       <!-- 武器总览容器（包含连线层） -->
@@ -216,12 +225,16 @@
 
   <!-- 自定义基质重合检测弹窗 -->
   <overlap-detection-dialog />
+
+  <!-- 宝藏基质导出弹窗 -->
+  <matrix-export-dialog v-model="showExportDialog" />
 </template>
 
 <script lang="ts" setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import CustomStatIcon from '@/components/CustomStatIcon.vue'
 import ItemIcon from '@/components/ItemIcon.vue'
+import MatrixExportDialog from '@/components/MatrixExportDialog.vue'
 import OverlapDetectionDialog from '@/components/OverlapDetectionDialog.vue'
 import WeaponDetailDialog from '@/components/WeaponDetailDialog.vue'
 import { useCustomStats } from '@/composables/useCustomStats'
@@ -371,6 +384,9 @@ function getWeaponSkillIcon(weaponId: string): string | null {
 
 // 武器详情弹窗（null=关闭，string=打开编辑该武器）
 const detailWeaponId = ref<string | null>(null)
+
+// 导出为图片弹窗
+const showExportDialog = ref(false)
 
 /**
  * 计算指定武器的属性组合键。

--- a/frontend/src/pages/treasure-matrix.vue
+++ b/frontend/src/pages/treasure-matrix.vue
@@ -227,6 +227,15 @@
           >
             添加武器
           </v-btn>
+          <v-btn
+            class="mt-2 ml-2"
+            color="secondary"
+            prepend-icon="mdi-image-outline"
+            variant="tonal"
+            @click="showExportDialog = true"
+          >
+            导出为图片
+          </v-btn>
         </v-expansion-panel-text>
       </v-expansion-panel>
 
@@ -543,6 +552,9 @@
       </v-card>
     </v-dialog>
 
+    <!-- 导出为图片弹窗 -->
+    <matrix-export-dialog v-model="showExportDialog" />
+
     <!-- 回到顶部按钮 -->
     <back-to-top />
   </v-container>
@@ -554,6 +566,7 @@ import { useRouter } from 'vue-router'
 import BackToTop from '@/components/BackToTop.vue'
 import CustomStatIcon from '@/components/CustomStatIcon.vue'
 import ItemIcon from '@/components/ItemIcon.vue'
+import MatrixExportDialog from '@/components/MatrixExportDialog.vue'
 import WeaponOverview from '@/components/WeaponOverview.vue'
 import { useCustomStats } from '@/composables/useCustomStats'
 import { type TreasureMatrixEntry, useProfiles } from '@/composables/useProfiles'
@@ -592,6 +605,7 @@ const { weaponsMap, weaponTypes, matrixIcons } = useStaticData()
 const essenceBgSrc = computed(() => matrixIcons.value.essenceBg)
 
 const showAddWeaponDialog = ref(false)
+const showExportDialog = ref(false)
 const weaponSearch = ref('')
 const computing = ref(false)
 

--- a/frontend/src/utils/__tests__/matrixExport.test.ts
+++ b/frontend/src/utils/__tests__/matrixExport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computeCanvasSize, pickColumns } from '@/utils/matrixExport'
+import { buildArchiveNo, computeCanvasSize, pickColumns, YITULIU_QR } from '@/utils/matrixExport'
 
 describe('pickColumns', () => {
   it('条目很少时每张卡各占一列，不留空位', () => {
@@ -64,5 +64,54 @@ describe('computeCanvasSize', () => {
     const size = computeCanvasSize(3, 0, 0)
     expect(Number.isFinite(size.width)).toBe(true)
     expect(size.weaponRows).toBe(3)
+  })
+})
+
+describe('buildArchiveNo', () => {
+  it('补零到三位，条目数变化时页脚宽度不跳动', () => {
+    expect(buildArchiveNo(7)).toBe('EER-007-MATRIX')
+    expect(buildArchiveNo(77)).toBe('EER-077-MATRIX')
+    expect(buildArchiveNo(770)).toBe('EER-770-MATRIX')
+  })
+
+  it('超过三位时不截断', () => {
+    expect(buildArchiveNo(1234)).toBe('EER-1234-MATRIX')
+  })
+
+  it('非法输入兜底成 0，不把 NaN 画到图上', () => {
+    expect(buildArchiveNo(-5)).toBe('EER-000-MATRIX')
+    expect(buildArchiveNo(Number.NaN)).toBe('EER-000-MATRIX')
+    expect(buildArchiveNo(3.7)).toBe('EER-003-MATRIX')
+  })
+})
+
+describe('YITULIU_QR', () => {
+  // 点阵是离线生成后写死的，肉眼看不出改坏了没有，只能靠 QR 自身的固定结构兜底
+  const FINDER = ['1111111', '1000001', '1011101', '1011101', '1011101', '1000001', '1111111']
+
+  function readFinder(top: number, left: number): string[] {
+    return FINDER.map((_, row) => YITULIU_QR[top + row]!.slice(left, left + FINDER.length))
+  }
+
+  it('是 25×25 的合法点阵', () => {
+    expect(YITULIU_QR).toHaveLength(25)
+    for (const row of YITULIU_QR) {
+      expect(row).toMatch(/^[01]{25}$/)
+    }
+  })
+
+  it('三个角上的定位图案完整', () => {
+    expect(readFinder(0, 0)).toEqual(FINDER)
+    expect(readFinder(0, 18)).toEqual(FINDER)
+    expect(readFinder(18, 0)).toEqual(FINDER)
+  })
+
+  it('定时图案保持交替，解码器靠它对齐网格', () => {
+    const timingRow = YITULIU_QR[6]!.slice(8, 17)
+    const timingColumn = YITULIU_QR.slice(8, 17)
+      .map((row) => row[6])
+      .join('')
+    expect(timingRow).toBe('101010101')
+    expect(timingColumn).toBe('101010101')
   })
 })

--- a/frontend/src/utils/__tests__/matrixExport.test.ts
+++ b/frontend/src/utils/__tests__/matrixExport.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { computeCanvasSize, pickColumns } from '@/utils/matrixExport'
+
+describe('pickColumns', () => {
+  it('条目很少时每张卡各占一列，不留空位', () => {
+    expect(pickColumns(1)).toBe(1)
+    expect(pickColumns(2)).toBe(2)
+    expect(pickColumns(3)).toBe(3)
+  })
+
+  it('按总数分档扩列', () => {
+    expect(pickColumns(4)).toBe(3)
+    expect(pickColumns(8)).toBe(3)
+    expect(pickColumns(9)).toBe(4)
+    expect(pickColumns(18)).toBe(4)
+    expect(pickColumns(19)).toBe(5)
+    expect(pickColumns(40)).toBe(5)
+    expect(pickColumns(41)).toBe(6)
+    expect(pickColumns(200)).toBe(6)
+  })
+
+  it('总数为 0 时也要返回合法列数，避免除零', () => {
+    expect(pickColumns(0)).toBe(1)
+  })
+})
+
+describe('computeCanvasSize', () => {
+  it('宽度只由列数决定，与条目数无关', () => {
+    const few = computeCanvasSize(3, 0, 3)
+    const many = computeCanvasSize(30, 0, 3)
+    expect(few.width).toBe(many.width)
+  })
+
+  it('行数按列数向上取整', () => {
+    expect(computeCanvasSize(7, 5, 3)).toMatchObject({ weaponRows: 3, customRows: 2 })
+  })
+
+  it('没有自定义基质时不为该区留高度', () => {
+    const withCustom = computeCanvasSize(6, 3, 3)
+    const withoutCustom = computeCanvasSize(6, 0, 3)
+    expect(withoutCustom.customRows).toBe(0)
+    expect(withoutCustom.height).toBeLessThan(withCustom.height)
+  })
+
+  it('只有自定义基质时不为内置武器区留高度', () => {
+    const onlyCustom = computeCanvasSize(0, 3, 3)
+    const onlyWeapon = computeCanvasSize(3, 0, 3)
+    expect(onlyCustom.weaponRows).toBe(0)
+    // 两区各一行、区标题各一个，缺少区间距的情况下高度应当相等
+    expect(onlyCustom.height).toBe(onlyWeapon.height)
+  })
+
+  it('两区都有时高度比单区多出一个区间距', () => {
+    const both = computeCanvasSize(3, 3, 3)
+    const onlyWeapon = computeCanvasSize(3, 0, 3)
+    const oneSectionExtra = both.height - onlyWeapon.height
+    // 多出的部分 = 区间距 + 区标题 + 一行卡片
+    expect(oneSectionExtra).toBeGreaterThan(0)
+    expect(both.weaponRows).toBe(1)
+    expect(both.customRows).toBe(1)
+  })
+
+  it('列数为 0 时兜底成 1 列，不产生 Infinity', () => {
+    const size = computeCanvasSize(3, 0, 0)
+    expect(Number.isFinite(size.width)).toBe(true)
+    expect(size.weaponRows).toBe(3)
+  })
+})

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -25,6 +25,8 @@ export interface ExportCard {
   maxed: boolean
   /** 扫描到的基质枚数；缺省或非正数时不画角标 */
   badgeCount?: number
+  /** 三词条中文名，如 ["攻击", "终结技充能效率", "巧技"] */
+  traitNames?: string[]
 }
 
 /**
@@ -106,16 +108,17 @@ const HEADER_H = 62
 const SECTION_HEAD_H = 30
 const CARD_W = 260
 const CARD_H = 132
-const CARD_R = 8
+const CARD_R = 3
 const CARD_PAD = 12
 const NAME_H = 22
-const ICON = 76
+const ICON = 56
 const MATRIX_ICON = 56
 const PIP_W = 8
-const PIP_H = 17
+const PIP_H = 12
 const PIP_GAP = 3
-const PIP_ROW_GAP = 26
+const PIP_ROW_GAP = 21
 const BADGE_R = 11
+const TRAIT_FONTSIZE = 12
 
 /** 画布单边的设备像素上限，取远低于 Chromium 16384 的保守值 */
 const MAX_DEVICE_PX = 8192
@@ -300,7 +303,7 @@ function drawImagePlaceholder(
 ): void {
   ctx.fillStyle = withAlpha(theme.onSurface, 0.08)
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, 6)
+  ctx.roundRect(x, y, size, size, 3)
   ctx.fill()
 
   ctx.fillStyle = withAlpha(theme.onSurface, 0.35)
@@ -314,7 +317,7 @@ function drawImagePlaceholder(
  * 画武器 icon：图片 + 底部稀有度渐变 + 底部色条。
  *
  * 对应 ItemIcon.vue 的三层结构，但不画 icon 内嵌名称——
- * 76px 见方塞中文名不可读，名称在卡片里有独立一行。
+ * 56px 见方塞中文名不可读，名称在卡片里有独立一行。
  */
 function drawWeaponIcon(
   ctx: CanvasRenderingContext2D,
@@ -332,7 +335,7 @@ function drawWeaponIcon(
 
   ctx.save()
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, 6)
+  ctx.roundRect(x, y, size, size, 3)
   ctx.clip()
 
   drawImageCover(ctx, image, x, y, size, size)
@@ -373,7 +376,7 @@ function drawEssenceIcon(
 
   ctx.save()
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, [6, 6, 0, 0])
+  ctx.roundRect(x, y, size, size, 3)
   ctx.clip()
 
   ctx.fillStyle = '#ffffff'
@@ -398,7 +401,7 @@ function drawEssenceIcon(
   ctx.strokeStyle = withAlpha(CUSTOM_ORANGE, 0.5)
   ctx.lineWidth = 2
   ctx.beginPath()
-  ctx.roundRect(x + 1, y + 1, size - 2, size - 2, [6, 6, 0, 0])
+  ctx.roundRect(x + 1, y + 1, size - 2, size - 2, 3)
   ctx.stroke()
 }
 
@@ -426,7 +429,7 @@ function drawPipRow(
     }
 
     ctx.beginPath()
-    ctx.roundRect(pipX, y, PIP_W, PIP_H, 4)
+    ctx.roundRect(pipX, y, PIP_W, PIP_H, 2)
     ctx.fill()
     clearShadow(ctx)
   }
@@ -477,6 +480,20 @@ function drawBadge(
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(count > 99 ? '99+' : String(count), centerX, centerY)
+}
+
+/**
+ * 处理词条名称：去掉"提升"后缀以缩短显示长度。
+ *
+ * "攻击力提升" → "攻击"
+ * "终结技充能效率提升" → "终结技充能效率"
+ * "巧技" → "巧技"（无"提升"则保持不变）
+ */
+function shortenTraitName(name: string): string {
+  if (name.endsWith('提升')) {
+    return name.slice(0, -2)
+  }
+  return name
 }
 
 /** 画一整张卡片 */
@@ -541,6 +558,18 @@ function drawCard(
       pipX,
       bodyY + slot * PIP_ROW_GAP,
     )
+  }
+
+  // 底部词条名
+  if (card.traitNames && card.traitNames.length > 0) {
+    const traitText = card.traitNames.map((name) => shortenTraitName(name)).join('·')
+    const traitMaxWidth = CARD_W - CARD_PAD * 2
+    const traitY = y + CARD_H - CARD_PAD - 4
+    ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'bottom'
+    const fittedText = fitText(ctx, traitText, traitMaxWidth, TRAIT_FONTSIZE, 10, 400)
+    ctx.fillText(fittedText, x + CARD_W / 2, traitY)
   }
 
   if (card.maxed) drawRainbowBorder(ctx, x, y, CARD_W, CARD_H)

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -2,8 +2,12 @@
  * 宝藏基质导出图的 Canvas 绘制模块。
  *
  * 这里只负责「把一组卡片画成一张 PNG」，不感知任何应用状态：
- * 调用方把 profile、静态数据、主题色整理成普通对象传进来。
+ * 调用方把 profile、静态数据整理成普通对象传进来。
  * 这样布局计算能在 node 环境的单测里直接跑，无需 DOM。
+ *
+ * 视觉基调是「工业档案」：灰白混凝土底、黑灰文字、工程黄只做锚点、
+ * 蓝青只做数据。配色是写死的常量，不跟随 Vuetify 主题——导出图是给别人
+ * 看的成品，同一份数据在任何机器、任何主题下都应该产出同一张图。
  */
 
 import Color from 'color'
@@ -21,7 +25,7 @@ export interface ExportCard {
   essenceBgUrl: string
   /** 技能属性图标地址 */
   skillIconUrl: string | null
-  /** 底部色条颜色：内置武器用稀有度色，自定义基质用橙色 */
+  /** 物品识别色：内置武器用稀有度色，自定义基质用橙色。全图仅此一处保留高饱和 */
   tierColor: string
   levels: readonly [number, number, number]
   maxed: boolean
@@ -29,22 +33,8 @@ export interface ExportCard {
   badgeCount?: number
   /** 三词条中文名，如 ["攻击", "终结技充能效率", "巧技"] */
   traitNames?: string[]
-  /** 未获得的条目：整张卡片降透明度 + 去色绘制 */
+  /** 未获得的条目：整张卡片降级到背景层 */
   dimmed?: boolean
-}
-
-/**
- * 绘制用的主题色。
- *
- * canvas 读不到 `--v-theme-*` 这类 CSS 变量，颜色必须由调用方从
- * Vuetify 的 `useTheme()` 里取出来显式传入。
- */
-export interface ExportTheme {
-  primary: string
-  onPrimary: string
-  background: string
-  surface: string
-  onSurface: string
 }
 
 export interface MatrixExportInput {
@@ -52,9 +42,10 @@ export interface MatrixExportInput {
   weapons: readonly ExportCard[]
   /** 自定义基质卡，永远画在最下方 */
   customs: readonly ExportCard[]
+  /** 数据库名，画在页头的筛选栏里，如 "default · 宝藏基质" */
   title: string
+  /** 归档时间等辅助信息，画在右上角档案抬头的末行 */
   subtitle: string
-  theme: ExportTheme
   /** 像素倍率，默认 2；超出画布上限时内部自动降级 */
   scale?: number
   /** 网格列数，不传则按卡片总数自适应 */
@@ -74,45 +65,132 @@ export interface MatrixExportResult {
   missingImages: number
 }
 
+// --- 工业档案色板 ---
+
+/**
+ * 全图配色。
+ *
+ * 彩色被严格限制在三组：工程黄（锚点/警示/重点）、蓝青（数据）、
+ * 物品自身的稀有度色（识别）。其余一律走这张灰阶表。
+ */
+const INK = {
+  /** 页面底：混凝土灰白 */
+  bg: '#e8e6e1',
+  /** 卡面。略带透明度，让背景的噪点与网格隐约透上来，形成面板质感 */
+  surface: 'rgba(244, 242, 238, 0.9)',
+  /** 未获得卡片的卡面：压向背景色，整张卡退到后景 */
+  surfaceDim: 'rgba(226, 224, 218, 0.72)',
+  /** 基质底板的衬底，比卡面略暖 */
+  plate: '#faf8f4',
+  /** 主文字 */
+  text: '#1c1c1a',
+  /** 次文字 */
+  muted: '#6b6862',
+  /** 结构线 */
+  line: '#c4c0b8',
+  /** 薄金属框的内衬线 */
+  lineSoft: '#dcd8d0',
+  /** 工程黄 */
+  yellow: '#e5b833',
+  /** 黄底上的文字色 */
+  yellowInk: '#3a2c00',
+} as const
+
+/** 未获得卡片专用的浅色文字，比 muted 再淡一档 */
+const DIM_TEXT = '#95918a'
+const DIM_MUTED = '#adaaa3'
+const DIM_LINE = '#d8d4cc'
+
+/** 三行词条的数据色：深蓝 → 青蓝 → 灰蓝 */
+const PIP_COLORS = ['#2d5f8a', '#3d8b8b', '#5a6b7a'] as const
+/** 未激活方格 */
+const PIP_IDLE = '#d3cfc7'
+/** 未获得卡片的方格：连未激活色都再压一档，扫一眼就知道整行是空的 */
+const PIP_IDLE_DIM = '#dfdcd5'
+
 /** 各词条的方格数，与 useWeaponStats 的 AFFIX_MAX_LEVEL 保持一致 */
 const AFFIX_PIP_COUNT = [6, 6, 3] as const
 
+// --- 字体 ---
+
+const FONT_STACK = '"HarmonyOS Sans SC", sans-serif'
+/** 编号、英文标签、数值：等宽字体是工业档案观感的主要来源 */
+const MONO_STACK = '"JetBrains Mono", "Fira Code", Consolas, monospace'
+/** 背景水墨字：楷体做书法感，缺字时回退衬线 */
+const BRUSH_STACK = '"KaiTi", "STKaiti", "SimSun", serif'
+
+// --- 档案文案 ---
+
+const BRAND_TITLE = '基质图鉴'
+const BRAND_TITLE_EN = 'MATRIX CATALOG'
+const ARCHIVE_ORG = '终末地基质档案'
+const ARCHIVE_ORG_EN = 'ENDFIELD ESSENCE ARCHIVES'
+/** 页头衬底的水墨字，与「基质」呼应 */
+const BRUSH_GLYPH = '基'
+
+// --- 署名与外链 ---
+
+const PROJECT_NAME = '终末地基质小助手'
+const PROJECT_REPO = 'github.com/Logical-Byte/endfield-essence-recognizer'
+/** 页脚右下的署名：开发组织 · 本页作者 · 开源协议 */
+const CREDIT_LINE = '逻辑元 LogicalByte · jiubook · AGPL-3.0'
+const YITULIU_NAME = '终末地一图流'
+const YITULIU_URL = 'ef.yituliu.cn'
+
 /**
- * 词条槽位配色。
+ * 一图流站点二维码的模块点阵（Version 2 / 纠错 M / 25×25）。
  *
- * 基础属性跟随主题 primary，另外两个沿用 treasure-matrix.vue 里
- * $attr-teal / $attr-indigo 的字面值，保证导出图与页面观感一致。
+ * 内容固定为 https://ef.yituliu.cn/，所以离线生成一次写死在这里：
+ * 为导出图里的一个角标引入运行时 QR 依赖不划算，写死也顺带保证
+ * 任何机器上画出的点阵完全一致。地址变更时用下面这段重新生成整块常量：
+ *
+ * ```
+ * npm i qrcode --prefix /tmp/qrgen --no-save
+ * NODE_PATH=/tmp/qrgen/node_modules node -e "const QR=require('qrcode');
+ *   const q=QR.create('https://ef.yituliu.cn/',{errorCorrectionLevel:'M'});
+ *   const n=q.modules.size;for(let y=0;y<n;y++){let r='';
+ *   for(let x=0;x<n;x++)r+=q.modules.get(x,y)?'1':'0';console.log(r)}"
+ * ```
  */
-const ATTR_TEAL = '#48a9a6'
-const ATTR_INDIGO = '#5c6bc0'
-
-/** 满级彩虹环的渐变色，取自 WeaponOverview.vue 的 .rainbow-border */
-const RAINBOW_STOPS = [
-  '#ffffff',
-  '#ff4ada',
-  '#ff4e4e',
-  '#ff9832',
-  '#ffff00',
-  '#00ff00',
-  '#00ffff',
-  '#79a0fd',
-  '#d46eff',
-  '#ff8df0',
-  '#ffffff',
-] as const
-
-/** 自定义基质的主题橙，与 CustomStatIcon.vue 一致 */
-const CUSTOM_ORANGE = '#ff7100'
+export const YITULIU_QR: readonly string[] = [
+  '1111111011001111101111111',
+  '1000001001001000001000001',
+  '1011101010101010101011101',
+  '1011101011001110101011101',
+  '1011101010010000001011101',
+  '1000001011010000101000001',
+  '1111111010101010101111111',
+  '0000000000001110000000000',
+  '0011111100001100110111101',
+  '1101100001110101110100001',
+  '0110111001000111100001001',
+  '1100110100010000001110000',
+  '0000001000000101101001011',
+  '0001110010101110111001110',
+  '1110011010011010001100101',
+  '0110010100111011100010110',
+  '1100101101111101111110110',
+  '0000000000100010100011101',
+  '1111111010101000101011001',
+  '1000001011110111100010011',
+  '1011101010001011111111011',
+  '1011101010100110010101111',
+  '1011101010001000101011101',
+  '1000001001101110001011001',
+  '1111111000111011001011111',
+]
 
 // --- 布局常量（CSS 像素）---
-const PAGE_PAD = 24
+const PAGE_PAD = 26
 const GAP = 14
-const SECTION_GAP = 22
-const HEADER_H = 62
-const SECTION_HEAD_H = 30
+const SECTION_GAP = 26
+const HEADER_H = 148
+const FOOTER_H = 66
+const SECTION_HEAD_H = 34
 const CARD_W = 260
 const CARD_H = 144
-const CARD_R = 3
+/** 卡片右上角的切角边长。工业面板不用圆角，只用极小的斜切 */
+const CARD_CHAMFER = 9
 const CARD_PAD = 12
 const NAME_H = 22
 /** 名称上方的注音行高度；不管有没有星级都占位，两类卡片的名称才对得齐 */
@@ -124,22 +202,21 @@ const PIP_W = 8
 const PIP_H = 12
 const PIP_GAP = 3
 const PIP_ROW_GAP = 21
-const BADGE_R = 11
+const BADGE_R = 10
 const TRAIT_FONTSIZE = 12
-
-/**
- * 未获得条目的置灰参数，对应总览页 `.weapon-not-owned` 的 `opacity/filter`。
- *
- * 透明度比页面上的 0.4 略高：页面只灰化图标，导出图整张卡片一起灰，
- * 名称和词条名再压到 0.4 就基本读不出来了。
- */
-const DIMMED_ALPHA = 0.45
-const DIMMED_FILTER = 'grayscale(0.8)'
+/** 数据库筛选栏高度 */
+const DB_BAR_H = 32
+/** 二维码每个模块的边长 */
+const QR_MODULE = 2
+/** 二维码四周留出的静区模块数，太窄会影响识别 */
+const QR_QUIET = 3
+/** 二维码底板边长：点阵本体加两侧静区 */
+const QR_BOX = (YITULIU_QR.length + QR_QUIET * 2) * QR_MODULE
+/** 背景工业网格的间距 */
+const GRID_STEP = 44
 
 /** 画布单边的设备像素上限，取远低于 Chromium 16384 的保守值 */
 const MAX_DEVICE_PX = 8192
-
-const FONT_STACK = '"HarmonyOS Sans SC", sans-serif'
 
 /**
  * 按卡片总数选择网格列数。
@@ -152,6 +229,19 @@ export function pickColumns(cardCount: number): number {
   if (cardCount <= 18) return 4
   if (cardCount <= 40) return 5
   return 6
+}
+
+/**
+ * 生成页脚的档案编号。
+ *
+ * 补零到三位，等宽字体下宽度稳定，条目数变化时页脚不会跳动。
+ *
+ * @param count 导出的条目总数。
+ * @returns 形如 `EER-077-MATRIX` 的编号。
+ */
+export function buildArchiveNo(count: number): string {
+  const safe = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0
+  return `EER-${String(safe).padStart(3, '0')}-MATRIX`
 }
 
 /**
@@ -178,7 +268,7 @@ export function computeCanvasSize(
     if (weaponRows > 0) height += SECTION_GAP
     height += SECTION_HEAD_H + customRows * (CARD_H + GAP) - GAP
   }
-  height += PAGE_PAD
+  height += SECTION_GAP + FOOTER_H + PAGE_PAD
 
   return { width, height, weaponRows, customRows }
 }
@@ -233,26 +323,23 @@ function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
   })
 }
 
-/** 以 rgba 形式取主题色的透明度变体 */
+/** 以 rgba 形式取颜色的透明度变体 */
 function withAlpha(color: string, alpha: number): string {
   return Color(color).alpha(alpha).string()
 }
 
 /**
- * 把主题色统一规范成 canvas 一定认得的 rgb 字符串。
+ * 把外部传入的颜色规范成 canvas 一定认得的字符串。
  *
- * canvas 对无效的 fillStyle 是静默忽略的——一个 undefined 会让文字直接消失，
- * 而不是报错。这里先过一遍 color 包（它把无效值兜底成黑色），
- * 让"取色取错了"至少表现为颜色不对，而不是整块内容不翼而飞。
+ * canvas 对无效的 fillStyle 是静默忽略的——一个 undefined 会让整块内容
+ * 不翼而飞，而不是报错。这里先过一遍 color 包（它把无效值兜底成黑色），
+ * 让"取色取错了"至少表现为颜色不对。只有 tierColor 来自外部，需要这层兜底。
  */
-function normalizeTheme(theme: ExportTheme): ExportTheme {
-  const toRgb = (color: string) => Color(color).string()
-  return {
-    primary: toRgb(theme.primary),
-    onPrimary: toRgb(theme.onPrimary),
-    background: toRgb(theme.background),
-    surface: toRgb(theme.surface),
-    onSurface: toRgb(theme.onSurface),
+function safeColor(color: string): string {
+  try {
+    return Color(color).string()
+  } catch {
+    return INK.muted
   }
 }
 
@@ -269,13 +356,14 @@ function fitText(
   maxFontSize: number,
   minFontSize: number,
   weight = 700,
+  family = FONT_STACK,
 ): string {
-  ctx.font = `${weight} ${maxFontSize}px ${FONT_STACK}`
+  ctx.font = `${weight} ${maxFontSize}px ${family}`
   const fullWidth = ctx.measureText(text).width
   if (fullWidth <= maxWidth) return text
 
   const scaled = Math.max((maxFontSize * maxWidth) / fullWidth, minFontSize)
-  ctx.font = `${weight} ${scaled}px ${FONT_STACK}`
+  ctx.font = `${weight} ${scaled}px ${family}`
   if (ctx.measureText(text).width <= maxWidth) return text
 
   // 缩到下限仍放不下，只能截断
@@ -286,12 +374,82 @@ function fitText(
   return `${truncated}…`
 }
 
-/** 清掉阴影设置。canvas 的 shadow 是全局状态，画完必须复位，否则后续绘制全带影子 */
-function clearShadow(ctx: CanvasRenderingContext2D): void {
-  ctx.shadowColor = 'transparent'
-  ctx.shadowBlur = 0
-  ctx.shadowOffsetX = 0
-  ctx.shadowOffsetY = 0
+/**
+ * 画带字距的文字并返回占用宽度。
+ *
+ * 等宽小字拉开字距是工业档案标签的主要观感来源。
+ * letterSpacing 是 ctx 的全局状态，画完必须复位，否则后续文字全被撑开。
+ */
+function drawTracked(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  spacing: number,
+): number {
+  ctx.letterSpacing = `${spacing}px`
+  const width = ctx.measureText(text).width
+  ctx.fillText(text, x, y)
+  ctx.letterSpacing = '0px'
+  return width
+}
+
+/** 测量带字距文字的宽度，不绘制 */
+function measureTracked(ctx: CanvasRenderingContext2D, text: string, spacing: number): number {
+  ctx.letterSpacing = `${spacing}px`
+  const width = ctx.measureText(text).width
+  ctx.letterSpacing = '0px'
+  return width
+}
+
+/** 画一条 1px 细线。canvas 的整数坐标落在像素边界上，偏移半像素才不发虚 */
+function drawHairline(
+  ctx: CanvasRenderingContext2D,
+  color: string,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): void {
+  ctx.strokeStyle = color
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(x1, y1 + 0.5)
+  ctx.lineTo(x2, y2 + 0.5)
+  ctx.stroke()
+}
+
+/**
+ * 生成切角矩形路径。
+ *
+ * 工业面板的边缘是斜切而不是圆角，斜切边本身就是一种结构暗示。
+ *
+ * @param cut 切角边长；传 0 得到纯直角矩形。
+ * @param corners 要切的角，顺序为左上、右上、右下、左下。
+ */
+function chamferPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  cut: number,
+  corners: readonly [boolean, boolean, boolean, boolean] = [false, true, false, false],
+): void {
+  const [topLeft, topRight, bottomRight, bottomLeft] = corners
+  const size = Math.max(0, Math.min(cut, width / 2, height / 2))
+
+  ctx.beginPath()
+  ctx.moveTo(x + (topLeft ? size : 0), y)
+  ctx.lineTo(x + width - (topRight ? size : 0), y)
+  if (topRight) ctx.lineTo(x + width, y + size)
+  ctx.lineTo(x + width, y + height - (bottomRight ? size : 0))
+  if (bottomRight) ctx.lineTo(x + width - size, y + height)
+  ctx.lineTo(x + (bottomLeft ? size : 0), y + height)
+  if (bottomLeft) ctx.lineTo(x, y + height - size)
+  ctx.lineTo(x, y + (topLeft ? size : 0))
+  if (topLeft) ctx.lineTo(x + size, y)
+  ctx.closePath()
 }
 
 /** 按 object-fit: cover 的规则把图片画进目标矩形 */
@@ -312,122 +470,589 @@ function drawImageCover(
 /** 图片缺失时的占位块 */
 function drawImagePlaceholder(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   x: number,
   y: number,
   size: number,
 ): void {
-  ctx.fillStyle = withAlpha(theme.onSurface, 0.08)
-  ctx.beginPath()
-  ctx.roundRect(x, y, size, size, 3)
-  ctx.fill()
+  ctx.fillStyle = withAlpha(INK.text, 0.06)
+  ctx.fillRect(x, y, size, size)
 
-  ctx.fillStyle = withAlpha(theme.onSurface, 0.35)
-  ctx.font = `700 ${Math.round(size * 0.32)}px ${FONT_STACK}`
+  ctx.strokeStyle = withAlpha(INK.text, 0.16)
+  ctx.lineWidth = 1
+  ctx.strokeRect(x + 0.5, y + 0.5, size - 1, size - 1)
+
+  ctx.fillStyle = withAlpha(INK.text, 0.3)
+  ctx.font = `700 ${Math.round(size * 0.3)}px ${MONO_STACK}`
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText('?', x + size / 2, y + size / 2)
 }
 
+// --- 背景层 ---
+
 /**
- * 画武器 icon：图片 + 底部稀有度渐变 + 底部色条。
+ * 生成噪点贴图，用作混凝土 / 旧纸的表面颗粒。
  *
- * 对应 ItemIcon.vue 的三层结构，但不画 icon 内嵌名称——
- * 56px 见方塞中文名不可读，名称在卡片里有独立一行。
+ * 用确定性的 xorshift 而不是 Math.random：同一份数据在任何机器上
+ * 都应产出逐像素一致的图，随机噪点会破坏这个保证。
+ *
+ * @param size 贴图边长，会以此为周期平铺。
+ */
+function makeNoiseTile(size: number): HTMLCanvasElement {
+  const tile = document.createElement('canvas')
+  tile.width = size
+  tile.height = size
+  const tileCtx = tile.getContext('2d')!
+  const imageData = tileCtx.createImageData(size, size)
+  const pixels = imageData.data
+
+  let seed = 0x9e_37_79_b9
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    // xorshift32
+    seed ^= seed << 13
+    seed >>>= 0
+    seed ^= seed >>> 17
+    seed ^= seed << 5
+    seed >>>= 0
+
+    const value = seed / 0xff_ff_ff_ff
+    // 一半暗点一半亮点：只压暗会发脏，只提亮会发灰，明暗混合才像水泥面
+    const dark = value < 0.5
+    const level = dark ? value * 2 : (value - 0.5) * 2
+    pixels[offset] = dark ? 0 : 255
+    pixels[offset + 1] = pixels[offset]!
+    pixels[offset + 2] = pixels[offset]!
+    pixels[offset + 3] = Math.round(level * (dark ? 12 : 16))
+  }
+
+  tileCtx.putImageData(imageData, 0, 0)
+  return tile
+}
+
+/**
+ * 铺满整页的纸面：底色 + 工业网格 + 表面颗粒。
+ *
+ * 三层全部压到几乎看不见的程度——它们只负责让大面积留白不显得空，
+ * 一旦影响到数据识别就是过头了。
+ */
+function drawPaper(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  ctx.fillStyle = INK.bg
+  ctx.fillRect(0, 0, width, height)
+
+  // 工业网格
+  ctx.strokeStyle = withAlpha(INK.text, 0.026)
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  for (let x = GRID_STEP; x < width; x += GRID_STEP) {
+    ctx.moveTo(x + 0.5, 0)
+    ctx.lineTo(x + 0.5, height)
+  }
+  for (let y = GRID_STEP; y < height; y += GRID_STEP) {
+    ctx.moveTo(0, y + 0.5)
+    ctx.lineTo(width, y + 0.5)
+  }
+  ctx.stroke()
+
+  // 表面颗粒
+  const pattern = ctx.createPattern(makeNoiseTile(96), 'repeat')
+  if (pattern) {
+    ctx.fillStyle = pattern
+    ctx.fillRect(0, 0, width, height)
+  }
+}
+
+/**
+ * 页头衬底的水墨字。
+ *
+ * 东方元素退到背景层：只留一个笔画结构，透明度压到几乎与底色同色，
+ * 靠 clip 让它被页头区裁掉一截，像盖印时压到了纸边。
+ */
+function drawBrushGlyph(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  ctx.save()
+  ctx.beginPath()
+  ctx.rect(x, y, width, height)
+  ctx.clip()
+
+  ctx.fillStyle = withAlpha(INK.text, 0.035)
+  ctx.font = `400 ${Math.round(height * 1.35)}px ${BRUSH_STACK}`
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(BRUSH_GLYPH, x + width * 0.26, y + height * 0.42)
+
+  ctx.restore()
+}
+
+/** 工业警示斜纹带，用作页脚的分隔元素 */
+function drawHazardStripes(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  if (width <= 0) return
+
+  ctx.save()
+  ctx.beginPath()
+  ctx.rect(x, y, width, height)
+  ctx.clip()
+
+  ctx.strokeStyle = withAlpha(INK.yellow, 0.5)
+  ctx.lineWidth = 3
+  ctx.beginPath()
+  // 45° 斜线，起点往左多退一个 height 才能让左边缘也被斜线覆盖满
+  for (let offset = -height; offset < width + height; offset += 9) {
+    ctx.moveTo(x + offset, y + height)
+    ctx.lineTo(x + offset + height, y)
+  }
+  ctx.stroke()
+
+  ctx.restore()
+}
+
+// --- 页头与页脚 ---
+
+/**
+ * 数据库筛选栏：把「哪个配置的哪类数据、共多少条」压成一条工业面板。
+ *
+ * 它承接大标题之后的信息层级——先知道看的是什么库，再进入具体条目。
+ */
+function drawDatabaseBar(
+  ctx: CanvasRenderingContext2D,
+  title: string,
+  count: number,
+  x: number,
+  y: number,
+  width: number,
+): void {
+  chamferPath(ctx, x, y, width, DB_BAR_H, 8, [false, true, false, true])
+  ctx.fillStyle = withAlpha(INK.text, 0.05)
+  ctx.fill()
+  ctx.strokeStyle = INK.line
+  ctx.lineWidth = 1
+  ctx.stroke()
+
+  // 两端的黄色端块：整条栏的视觉夹持点
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(x, y + 6, 4, DB_BAR_H - 12)
+  ctx.fillRect(x + width - 4, y + 6, 4, DB_BAR_H - 12)
+
+  const midY = y + DB_BAR_H / 2
+
+  // 右端：条目数。先画右侧才能算出左侧标题的可用宽度
+  ctx.textBaseline = 'middle'
+  ctx.textAlign = 'right'
+  ctx.fillStyle = INK.text
+  ctx.font = `800 15px ${MONO_STACK}`
+  const countText = String(count)
+  const countWidth = ctx.measureText(countText).width
+  ctx.fillText(countText, x + width - 14, midY)
+
+  ctx.fillStyle = INK.muted
+  ctx.font = `500 9px ${MONO_STACK}`
+  const itemsRight = x + width - 14 - countWidth - 8
+  const itemsWidth = measureTracked(ctx, 'ITEMS', 1.5)
+  ctx.textAlign = 'left'
+  drawTracked(ctx, 'ITEMS', itemsRight - itemsWidth, midY, 1.5)
+
+  // 左端：DATABASE 标签 + 竖分隔 + 库名
+  ctx.fillStyle = INK.muted
+  ctx.font = `500 9px ${MONO_STACK}`
+  const labelX = x + 16
+  const labelWidth = drawTracked(ctx, 'DATABASE', labelX, midY, 2)
+
+  const dividerX = labelX + labelWidth + 12
+  ctx.strokeStyle = INK.line
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(dividerX + 0.5, y + 8)
+  ctx.lineTo(dividerX + 0.5, y + DB_BAR_H - 8)
+  ctx.stroke()
+
+  const titleX = dividerX + 12
+  const titleMaxWidth = itemsRight - 16 - titleX
+  ctx.fillStyle = INK.text
+  const titleText = fitText(ctx, title, Math.max(40, titleMaxWidth), 13, 9)
+  ctx.fillText(titleText, titleX, midY)
+}
+
+/**
+ * 右上角的一图流二维码，做成工业档案里贴的资料标。
+ *
+ * 底板铺近白的 plate 色而不是直接落在页面底色上：浅灰会压低黑白模块的
+ * 对比度，影响识别。四角黄色角标与卡片上的基质图标同一套语言。
+ */
+function drawQrTag(ctx: CanvasRenderingContext2D, x: number, y: number): void {
+  chamferPath(ctx, x, y, QR_BOX, QR_BOX, 6, [false, true, false, true])
+  ctx.fillStyle = INK.plate
+  ctx.fill()
+  ctx.strokeStyle = INK.line
+  ctx.lineWidth = 1
+  ctx.stroke()
+
+  // 模块点阵，从静区之后开始铺
+  ctx.fillStyle = INK.text
+  const originX = x + QR_QUIET * QR_MODULE
+  const originY = y + QR_QUIET * QR_MODULE
+  for (const [row, bits] of YITULIU_QR.entries()) {
+    for (const [column, bit] of [...bits].entries()) {
+      if (bit === '1') {
+        ctx.fillRect(originX + column * QR_MODULE, originY + row * QR_MODULE, QR_MODULE, QR_MODULE)
+      }
+    }
+  }
+
+  const tick = 7
+  ctx.strokeStyle = INK.yellow
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  for (const [cornerX, cornerY, dirX, dirY] of [
+    [x, y, 1, 1],
+    [x + QR_BOX, y, -1, 1],
+    [x + QR_BOX, y + QR_BOX, -1, -1],
+    [x, y + QR_BOX, 1, -1],
+  ] as const) {
+    ctx.moveTo(cornerX + dirX * tick, cornerY)
+    ctx.lineTo(cornerX, cornerY)
+    ctx.lineTo(cornerX, cornerY + dirY * tick)
+  }
+  ctx.stroke()
+
+  // 站点名与地址：二维码扫不了时还能手打
+  ctx.textAlign = 'right'
+  ctx.textBaseline = 'top'
+  ctx.fillStyle = INK.muted
+  ctx.font = `500 9px ${FONT_STACK}`
+  ctx.fillText(YITULIU_NAME, x + QR_BOX, y + QR_BOX + 4)
+  ctx.fillStyle = withAlpha(INK.muted, 0.75)
+  ctx.font = `400 8px ${MONO_STACK}`
+  ctx.fillText(YITULIU_URL, x + QR_BOX, y + QR_BOX + 15)
+}
+
+/**
+ * 档案抬头：机构名 + 英文 + 细线 + 归档时间。
+ *
+ * @param maxWidth 可用宽度；窄图里二维码和大标题会挤掉它，压不进就整块不画，
+ *   宁可少一行辅助信息也不要和旁边的元素叠在一起。
+ */
+function drawArchiveStamp(
+  ctx: CanvasRenderingContext2D,
+  timestamp: string,
+  right: number,
+  y: number,
+  maxWidth: number,
+): void {
+  if (maxWidth < 90) return
+
+  ctx.textAlign = 'right'
+  ctx.textBaseline = 'middle'
+
+  ctx.fillStyle = INK.muted
+  ctx.font = `700 12px ${FONT_STACK}`
+  ctx.fillText(ARCHIVE_ORG, right, y + 8)
+
+  ctx.fillStyle = withAlpha(INK.muted, 0.75)
+  ctx.font = `500 9px ${MONO_STACK}`
+  const enWidth = Math.min(measureTracked(ctx, ARCHIVE_ORG_EN, 1.6), maxWidth)
+  ctx.textAlign = 'left'
+  drawTracked(ctx, ARCHIVE_ORG_EN, right - enWidth, y + 25, 1.6)
+
+  const lineLeft = right - Math.min(Math.max(enWidth, 150), maxWidth)
+  drawHairline(ctx, INK.line, lineLeft, y + 35, right, y + 35)
+  // 线左端的黄色起点，与左侧品牌区的黄竖线呼应
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(lineLeft, y + 33, 14, 2)
+
+  ctx.fillStyle = withAlpha(INK.muted, 0.8)
+  ctx.font = `400 9px ${MONO_STACK}`
+  ctx.textAlign = 'right'
+  ctx.fillText(timestamp, right, y + 47)
+}
+
+/** 画整个页头区：品牌块 + 档案抬头 + 二维码 + 数据库栏 */
+function drawHeader(
+  ctx: CanvasRenderingContext2D,
+  input: MatrixExportInput,
+  count: number,
+  x: number,
+  y: number,
+  width: number,
+): void {
+  drawBrushGlyph(ctx, x, y, width, HEADER_H - DB_BAR_H - 24)
+
+  // 大标题左侧的黄竖线：全图第一个视觉锚点
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(x, y + 2, 4, 30)
+
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'middle'
+  ctx.fillStyle = INK.text
+  ctx.font = `800 27px ${FONT_STACK}`
+  ctx.fillText(BRAND_TITLE, x + 15, y + 17)
+
+  ctx.fillStyle = INK.muted
+  ctx.font = `500 10px ${MONO_STACK}`
+  drawTracked(ctx, BRAND_TITLE_EN, x + 16, y + 41, 3.4)
+
+  // 标题下的黄色短横线，收住整个品牌块
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(x + 16, y + 51, 38, 3)
+
+  const qrX = x + width - QR_BOX
+  drawQrTag(ctx, qrX, y)
+
+  // 品牌块右边界固定按大标题宽度估，抬头从这里往右排
+  const stampRight = qrX - 18
+  drawArchiveStamp(ctx, input.subtitle, stampRight, y, stampRight - (x + 145))
+
+  drawDatabaseBar(ctx, input.title, count, x, y + HEADER_H - DB_BAR_H - 22, width)
+}
+
+/**
+ * 页脚：上行是标识与档案编号，下行是仓库地址与署名。
+ *
+ * 两行各自左右对齐、中间留空，窄图里也只是间距变小，不会互相压字。
+ */
+function drawFooter(
+  ctx: CanvasRenderingContext2D,
+  count: number,
+  x: number,
+  y: number,
+  width: number,
+): void {
+  drawHairline(ctx, INK.line, x, y, x + width, y)
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(x, y, 38, 2)
+
+  const mainY = y + 22
+  ctx.textBaseline = 'middle'
+  ctx.textAlign = 'left'
+
+  ctx.fillStyle = INK.text
+  ctx.font = `800 12px ${MONO_STACK}`
+  const brandWidth = drawTracked(ctx, 'EER', x, mainY, 1.5)
+
+  ctx.fillStyle = INK.muted
+  ctx.font = `500 10px ${FONT_STACK}`
+  const nameX = x + brandWidth + 10
+  const nameWidth = ctx.measureText(`· ${PROJECT_NAME}`).width
+  ctx.fillText(`· ${PROJECT_NAME}`, nameX, mainY)
+
+  // 右侧档案编号
+  ctx.textAlign = 'right'
+  ctx.fillStyle = INK.text
+  ctx.font = `700 11px ${MONO_STACK}`
+  const archiveNo = buildArchiveNo(count)
+  const archiveWidth = ctx.measureText(archiveNo).width
+  ctx.fillText(archiveNo, x + width, mainY)
+
+  ctx.fillStyle = INK.muted
+  ctx.font = `400 9px ${FONT_STACK}`
+  const labelRight = x + width - archiveWidth - 8
+  ctx.fillText('档案编号', labelRight, mainY)
+  const labelWidth = ctx.measureText('档案编号').width
+
+  const stripeLeft = nameX + nameWidth + 22
+  const stripeRight = labelRight - labelWidth - 22
+  drawHazardStripes(ctx, stripeLeft, mainY - 5, stripeRight - stripeLeft, 10)
+
+  // 下行：左仓库、右署名，各占一半宽度
+  const creditY = y + 47
+  const half = (width - 16) / 2
+
+  ctx.textAlign = 'left'
+  ctx.fillStyle = withAlpha(INK.muted, 0.8)
+  ctx.fillText(fitText(ctx, PROJECT_REPO, half, 9, 7, 400, MONO_STACK), x, creditY)
+
+  ctx.textAlign = 'right'
+  ctx.fillStyle = INK.muted
+  ctx.fillText(fitText(ctx, CREDIT_LINE, half, 9, 7, 500), x + width, creditY)
+}
+
+// --- 卡片 ---
+
+/**
+ * 一张卡片实际使用的色值。
+ *
+ * 未获得的条目不是简单地整体调低透明度，而是换一套压向背景的色板：
+ * 名称、边框、方格各自降到刚好还能辨认的程度，扫一眼就能把
+ * 「已拥有 = 前景 / 未拥有 = 背景」分开，不用去读数字。
+ */
+interface CardInk {
+  surface: string
+  border: string
+  borderInner: string
+  name: string
+  ruby: string
+  trait: string
+  pipIdle: string
+  /** 位图（武器图、基质图）的绘制透明度 */
+  imageAlpha: number
+}
+
+function cardInk(dimmed: boolean): CardInk {
+  if (dimmed) {
+    return {
+      surface: INK.surfaceDim,
+      border: DIM_LINE,
+      borderInner: 'transparent',
+      name: DIM_TEXT,
+      ruby: DIM_MUTED,
+      trait: DIM_MUTED,
+      pipIdle: PIP_IDLE_DIM,
+      imageAlpha: 0.4,
+    }
+  }
+  return {
+    surface: INK.surface,
+    border: INK.line,
+    borderInner: INK.lineSoft,
+    name: INK.text,
+    ruby: withAlpha(INK.text, 0.32),
+    trait: INK.muted,
+    pipIdle: PIP_IDLE,
+    imageAlpha: 1,
+  }
+}
+
+/**
+ * 画武器 icon：图片 + 底部稀有度色条 + 细边框。
+ *
+ * 对应 ItemIcon.vue 的层叠结构，但去掉了发光渐变——工业面板上的
+ * 缩略图就该是块平的铭牌图，稀有度只靠底部那条色带表达。
  */
 function drawWeaponIcon(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   image: HTMLImageElement | null,
   card: ExportCard,
+  ink: CardInk,
   x: number,
   y: number,
   size: number,
 ): void {
   if (!image) {
-    drawImagePlaceholder(ctx, theme, x, y, size)
+    drawImagePlaceholder(ctx, x, y, size)
     return
   }
 
+  const tierColor = safeColor(card.tierColor)
+
   ctx.save()
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, 3)
+  ctx.rect(x, y, size, size)
   ctx.clip()
 
-  drawImageCover(ctx, image, x, y, size, size)
-
-  // 底部 70%→100% 的稀有度色渐变
-  const gradient = ctx.createLinearGradient(x, y, x, y + size)
-  gradient.addColorStop(0.7, withAlpha(card.tierColor, 0))
-  gradient.addColorStop(1, withAlpha(card.tierColor, 0.3))
-  ctx.fillStyle = gradient
+  ctx.fillStyle = withAlpha(INK.text, 0.04)
   ctx.fillRect(x, y, size, size)
 
-  // 底部 4% 高的稀有度色条
-  const barHeight = Math.max(2, size * 0.04)
-  ctx.fillStyle = card.tierColor
+  ctx.globalAlpha = ink.imageAlpha
+  if (card.dimmed) ctx.filter = 'grayscale(1)'
+  drawImageCover(ctx, image, x, y, size, size)
+  ctx.filter = 'none'
+  ctx.globalAlpha = 1
+
+  // 底部稀有度色条：全图仅有的几处高饱和之一，负责物品识别
+  const barHeight = Math.max(2, size * 0.055)
+  ctx.fillStyle = card.dimmed ? withAlpha(tierColor, 0.35) : tierColor
   ctx.fillRect(x, y + size - barHeight, size, barHeight)
 
   ctx.restore()
+
+  ctx.strokeStyle = ink.border
+  ctx.lineWidth = 1
+  ctx.strokeRect(x + 0.5, y + 0.5, size - 1, size - 1)
 }
 
 /**
- * 画基质图：底板 + 技能图标 + 橙色渐变 + 底部橙条 + 橙色描边。
+ * 画基质图：底板 + 技能图标 + 黄色框体 + 四角角标。
  *
  * 对应 CustomStatIcon.vue 的层叠结构，技能图标沿用 translate(5%, -5%) 的偏移。
+ * 黄框和角标是卡片内的第二视觉锚点——先看到名称，再被引到这枚核心基质上。
+ *
+ * @param accent 底部识别条的颜色：内置武器用工程黄，自定义基质用它自己的橙。
  */
 function drawEssenceIcon(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   bgImage: HTMLImageElement | null,
   skillImage: HTMLImageElement | null,
+  ink: CardInk,
+  accent: string,
+  dimmed: boolean,
   x: number,
   y: number,
   size: number,
 ): void {
   if (!bgImage && !skillImage) {
-    drawImagePlaceholder(ctx, theme, x, y, size)
+    drawImagePlaceholder(ctx, x, y, size)
     return
   }
 
   ctx.save()
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, 3)
+  ctx.rect(x, y, size, size)
   ctx.clip()
 
-  ctx.fillStyle = '#ffffff'
+  ctx.fillStyle = INK.plate
   ctx.fillRect(x, y, size, size)
+
+  ctx.globalAlpha = ink.imageAlpha
+  if (dimmed) ctx.filter = 'grayscale(1)'
   if (bgImage) drawImageCover(ctx, bgImage, x, y, size, size)
   if (skillImage) {
     drawImageCover(ctx, skillImage, x + size * 0.05, y - size * 0.05, size, size)
   }
+  ctx.filter = 'none'
+  ctx.globalAlpha = 1
 
-  const gradient = ctx.createLinearGradient(x, y, x, y + size)
-  gradient.addColorStop(0.7, withAlpha(CUSTOM_ORANGE, 0))
-  gradient.addColorStop(1, withAlpha(CUSTOM_ORANGE, 0.3))
-  ctx.fillStyle = gradient
-  ctx.fillRect(x, y, size, size)
-
-  const barHeight = Math.max(2, size * 0.04)
-  ctx.fillStyle = CUSTOM_ORANGE
+  const barHeight = Math.max(2, size * 0.055)
+  ctx.fillStyle = dimmed ? withAlpha(accent, 0.35) : accent
   ctx.fillRect(x, y + size - barHeight, size, barHeight)
 
   ctx.restore()
 
-  ctx.strokeStyle = withAlpha(CUSTOM_ORANGE, 0.5)
+  // 黄色框体
+  const frameColor = dimmed ? withAlpha(INK.yellow, 0.3) : INK.yellow
+  ctx.strokeStyle = frameColor
+  ctx.lineWidth = 1.5
+  ctx.strokeRect(x + 0.75, y + 0.75, size - 1.5, size - 1.5)
+
+  // 四角角标：把「这是核心基质」再点一次，不靠加粗边框硬顶
+  const tick = 7
+  ctx.strokeStyle = frameColor
   ctx.lineWidth = 2
   ctx.beginPath()
-  ctx.roundRect(x + 1, y + 1, size - 2, size - 2, 3)
+  for (const [cornerX, cornerY, dirX, dirY] of [
+    [x, y, 1, 1],
+    [x + size, y, -1, 1],
+    [x + size, y + size, -1, -1],
+    [x, y + size, 1, -1],
+  ] as const) {
+    ctx.moveTo(cornerX + dirX * tick, cornerY)
+    ctx.lineTo(cornerX, cornerY)
+    ctx.lineTo(cornerX, cornerY + dirY * tick)
+  }
   ctx.stroke()
 }
 
-/** 画一行方格能量条，对应 treasure-matrix.vue 的 .attr-pips */
+/**
+ * 画一行方格能量条。
+ *
+ * 直角实心块、无发光：色块长度本身就是可读的量，扫一眼就知道高低，
+ * 不必真去读 6/6 那个数字。未激活块只降对比度、不消失，槽位总数才留得住。
+ */
 function drawPipRow(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   level: number,
   pipCount: number,
   activeColor: string,
+  ink: CardInk,
+  dimmed: boolean,
   x: number,
   y: number,
 ): void {
@@ -435,64 +1060,65 @@ function drawPipRow(
     const pipX = x + index * (PIP_W + PIP_GAP)
     const active = index < level
 
-    if (active) {
-      ctx.shadowColor = withAlpha(activeColor, 0.32)
-      ctx.shadowBlur = 7
-      ctx.shadowOffsetY = 2
-      ctx.fillStyle = activeColor
-    } else {
-      ctx.fillStyle = withAlpha(theme.onSurface, 0.12)
-    }
-
-    ctx.beginPath()
-    ctx.roundRect(pipX, y, PIP_W, PIP_H, 2)
-    ctx.fill()
-    clearShadow(ctx)
+    ctx.fillStyle = active ? (dimmed ? withAlpha(activeColor, 0.32) : activeColor) : ink.pipIdle
+    ctx.fillRect(pipX, y, PIP_W, PIP_H)
   }
 
-  ctx.fillStyle = withAlpha(theme.onSurface, 0.68)
-  ctx.font = `800 10px ${FONT_STACK}`
+  ctx.fillStyle = dimmed ? ink.trait : withAlpha(INK.text, 0.62)
+  ctx.font = `700 10px ${MONO_STACK}`
   ctx.textAlign = 'left'
   ctx.textBaseline = 'middle'
-  ctx.fillText(`${level}/${pipCount}`, x + pipCount * (PIP_W + PIP_GAP) + 4, y + PIP_H / 2)
+  ctx.fillText(`${level}/${pipCount}`, x + pipCount * (PIP_W + PIP_GAP) + 5, y + PIP_H / 2)
 }
 
-/** 满级卡片的彩虹外框，取 WeaponOverview.vue 彩虹环渐变的一帧 */
-function drawRainbowBorder(
+/**
+ * 满级标记：黄色双线框 + 右上切角实心三角。
+ *
+ * 页面上用的是彩虹环，但彩虹渐变落在灰白工业底上会盖过所有数据。
+ * 这里改用「已认证」式的黄色标识，纳入全图统一的黄色锚点体系。
+ */
+function drawMaxedMark(
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
   width: number,
   height: number,
 ): void {
-  // 45° 方向：从左下到右上
-  const gradient = ctx.createLinearGradient(x, y + height, x + width, y)
-  for (const [index, color] of RAINBOW_STOPS.entries()) {
-    gradient.addColorStop(index / (RAINBOW_STOPS.length - 1), color)
-  }
-
-  ctx.strokeStyle = gradient
-  ctx.lineWidth = 2
-  ctx.beginPath()
-  ctx.roundRect(x + 1, y + 1, width - 2, height - 2, CARD_R)
+  chamferPath(ctx, x + 1, y + 1, width - 2, height - 2, CARD_CHAMFER - 1)
+  ctx.strokeStyle = INK.yellow
+  ctx.lineWidth = 1.5
   ctx.stroke()
+
+  chamferPath(ctx, x + 3.5, y + 3.5, width - 7, height - 7, CARD_CHAMFER - 3)
+  ctx.strokeStyle = withAlpha(INK.yellow, 0.32)
+  ctx.lineWidth = 1
+  ctx.stroke()
+
+  // 右上切角处的实心三角，等同档案上的「已归档」戳
+  ctx.fillStyle = INK.yellow
+  ctx.beginPath()
+  ctx.moveTo(x + width - CARD_CHAMFER - 8, y + 1)
+  ctx.lineTo(x + width - 1, y + CARD_CHAMFER + 8)
+  ctx.lineTo(x + width - 1, y + CARD_CHAMFER)
+  ctx.lineTo(x + width - CARD_CHAMFER, y + 1)
+  ctx.closePath()
+  ctx.fill()
 }
 
-/** 扫描数量角标，对应设置页 v-badge 的右上角圆形数字 */
+/** 扫描数量角标：黄色切角方块 + 深色数字 */
 function drawBadge(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   count: number,
   centerX: number,
   centerY: number,
 ): void {
-  ctx.fillStyle = theme.primary
-  ctx.beginPath()
-  ctx.arc(centerX, centerY, BADGE_R, 0, Math.PI * 2)
+  const size = BADGE_R * 2
+  chamferPath(ctx, centerX - BADGE_R, centerY - BADGE_R, size, size, 5, [true, false, true, false])
+  ctx.fillStyle = INK.yellow
   ctx.fill()
 
-  ctx.fillStyle = theme.onPrimary
-  ctx.font = `700 11px ${FONT_STACK}`
+  ctx.fillStyle = INK.yellowInk
+  ctx.font = `700 10px ${MONO_STACK}`
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(count > 99 ? '99+' : String(count), centerX, centerY)
@@ -512,45 +1138,56 @@ function shortenTraitName(name: string): string {
   return name
 }
 
-/** 画一整张卡片 */
+/**
+ * 画一整张卡片。
+ *
+ * 内部视觉顺序刻意做成 名称 → 武器 → 核心基质 → 数据：
+ * 星级虽然靠上但压得最淡，第一眼落到的应该是名字。
+ */
 function drawCard(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   card: ExportCard,
   images: Map<string, HTMLImageElement | null>,
   x: number,
   y: number,
 ): void {
-  // 无条件成对 save/restore：置灰只作用于当前这张卡，
-  // 漏掉 restore 会让后面所有卡片跟着变灰。
-  ctx.save()
-  if (card.dimmed) {
-    ctx.globalAlpha = DIMMED_ALPHA
-    ctx.filter = DIMMED_FILTER
-  }
+  const ink = cardInk(card.dimmed === true)
+  const dimmed = card.dimmed === true
 
-  ctx.fillStyle = theme.surface
-  ctx.beginPath()
-  ctx.roundRect(x, y, CARD_W, CARD_H, CARD_R)
+  // 无条件成对 save/restore：filter/globalAlpha 是全局状态，
+  // 漏掉 restore 会让后面所有卡片跟着变样。
+  ctx.save()
+
+  // 卡面：薄金属铭牌——直角为主，只切右上角
+  chamferPath(ctx, x, y, CARD_W, CARD_H, CARD_CHAMFER)
+  ctx.fillStyle = ink.surface
   ctx.fill()
-  ctx.strokeStyle = withAlpha(theme.onSurface, 0.12)
+  ctx.strokeStyle = ink.border
   ctx.lineWidth = 1
   ctx.stroke()
 
-  // 名称行
+  // 内衬线：一圈退进 3px 的更淡描边，做出金属框的厚度
+  if (ink.borderInner !== 'transparent') {
+    chamferPath(ctx, x + 3, y + 3, CARD_W - 6, CARD_H - 6, CARD_CHAMFER - 3)
+    ctx.strokeStyle = ink.borderInner
+    ctx.lineWidth = 1
+    ctx.stroke()
+  }
+
   const nameMaxWidth = CARD_W - CARD_PAD * 2
 
-  // 注音行：星级压到名称上方一行，小一号且半透明，不与名称抢视线
+  // 注音行：星级压到名称上方，透明度低到不与名称抢视线
   if (card.nameRuby) {
     const rubyText = fitText(ctx, card.nameRuby, nameMaxWidth, RUBY_FONTSIZE, 7)
-    ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
+    ctx.fillStyle = ink.ruby
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
     ctx.fillText(rubyText, x + CARD_W / 2, y + CARD_PAD + RUBY_H / 2)
   }
 
-  const nameText = fitText(ctx, card.name, nameMaxWidth, 14, 10)
-  ctx.fillStyle = theme.onSurface
+  // 名称：卡片内最重的文字
+  const nameText = fitText(ctx, card.name, nameMaxWidth, 15, 10, 800)
+  ctx.fillStyle = ink.name
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(nameText, x + CARD_W / 2, y + CARD_PAD + RUBY_H + NAME_H / 2)
@@ -563,32 +1200,53 @@ function drawCard(
   let pipX: number
   if (card.kind === 'weapon') {
     const iconX = x + CARD_PAD
-    drawWeaponIcon(ctx, theme, iconImage, card, iconX, bodyY, ICON)
+    drawWeaponIcon(ctx, iconImage, card, ink, iconX, bodyY, ICON)
 
     const essenceX = iconX + ICON + 10
     const essenceY = bodyY + (ICON - MATRIX_ICON) / 2
-    drawEssenceIcon(ctx, theme, bgImage, skillImage, essenceX, essenceY, MATRIX_ICON)
+    drawEssenceIcon(
+      ctx,
+      bgImage,
+      skillImage,
+      ink,
+      INK.yellow,
+      dimmed,
+      essenceX,
+      essenceY,
+      MATRIX_ICON,
+    )
     pipX = essenceX + MATRIX_ICON + 12
 
     if (card.badgeCount && card.badgeCount > 0) {
-      drawBadge(ctx, theme, card.badgeCount, iconX + ICON, bodyY)
+      drawBadge(ctx, card.badgeCount, iconX + ICON, bodyY)
     }
   } else {
-    // 自定义基质没有武器图，基质图放大占据 icon 的位置
+    // 自定义基质没有武器图，基质图放大占据 icon 的位置；
+    // 底条保留它自己的橙，作为「这是自定义项」的识别色
     const essenceX = x + CARD_PAD
-    drawEssenceIcon(ctx, theme, bgImage, skillImage, essenceX, bodyY, ICON)
+    drawEssenceIcon(
+      ctx,
+      bgImage,
+      skillImage,
+      ink,
+      safeColor(card.tierColor),
+      dimmed,
+      essenceX,
+      bodyY,
+      ICON,
+    )
     pipX = essenceX + ICON + 12
   }
 
   // 三行方格能量条
-  const pipColors = [theme.primary, ATTR_TEAL, ATTR_INDIGO]
   for (let slot = 0; slot < 3; slot++) {
     drawPipRow(
       ctx,
-      theme,
       card.levels[slot] ?? 0,
       AFFIX_PIP_COUNT[slot]!,
-      pipColors[slot]!,
+      PIP_COLORS[slot]!,
+      ink,
+      dimmed,
       pipX,
       bodyY + slot * PIP_ROW_GAP,
     )
@@ -596,42 +1254,61 @@ function drawCard(
 
   // 底部词条名
   if (card.traitNames && card.traitNames.length > 0) {
-    const traitText = card.traitNames.map((name) => shortenTraitName(name)).join('·')
+    const traitText = card.traitNames.map((name) => shortenTraitName(name)).join(' · ')
     const traitMaxWidth = CARD_W - CARD_PAD * 2
     const traitY = y + CARD_H - CARD_PAD - 4
-    ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
+    ctx.fillStyle = ink.trait
     ctx.textAlign = 'center'
     ctx.textBaseline = 'bottom'
     const fittedText = fitText(ctx, traitText, traitMaxWidth, TRAIT_FONTSIZE, 10, 400)
     ctx.fillText(fittedText, x + CARD_W / 2, traitY)
   }
 
-  if (card.maxed) drawRainbowBorder(ctx, x, y, CARD_W, CARD_H)
+  if (card.maxed && !dimmed) drawMaxedMark(ctx, x, y, CARD_W, CARD_H)
 
   ctx.restore()
 }
 
-/** 画区标题，返回下一个可用的 y 坐标 */
+/**
+ * 画区标题，返回下一个可用的 y 坐标。
+ *
+ * 结构与页头同源：黄块起头、中英双行、延伸线收尾、右端计数。
+ */
 function drawSectionHeader(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   text: string,
+  textEn: string,
+  count: number,
   x: number,
   y: number,
   width: number,
 ): number {
-  ctx.fillStyle = withAlpha(theme.onSurface, 0.62)
-  ctx.font = `700 14px ${FONT_STACK}`
+  const midY = y + SECTION_HEAD_H / 2 + 2
+
+  ctx.fillStyle = INK.yellow
+  ctx.fillRect(x, midY - 7, 4, 14)
+
   ctx.textAlign = 'left'
   ctx.textBaseline = 'middle'
-  ctx.fillText(text, x, y + SECTION_HEAD_H / 2)
+  ctx.fillStyle = INK.text
+  ctx.font = `700 14px ${FONT_STACK}`
+  const titleWidth = ctx.measureText(text).width
+  ctx.fillText(text, x + 12, midY)
 
-  ctx.strokeStyle = withAlpha(theme.onSurface, 0.12)
-  ctx.lineWidth = 1
-  ctx.beginPath()
-  ctx.moveTo(x + ctx.measureText(text).width + 12, y + SECTION_HEAD_H / 2)
-  ctx.lineTo(x + width, y + SECTION_HEAD_H / 2)
-  ctx.stroke()
+  ctx.fillStyle = withAlpha(INK.muted, 0.75)
+  ctx.font = `500 9px ${MONO_STACK}`
+  const enX = x + 12 + titleWidth + 10
+  const enWidth = drawTracked(ctx, textEn, enX, midY + 1, 1.8)
+
+  // 右端计数，先测宽度才能定延伸线的终点
+  ctx.textAlign = 'right'
+  ctx.fillStyle = INK.muted
+  ctx.font = `700 10px ${MONO_STACK}`
+  const countText = `${count} ITEMS`
+  const countWidth = ctx.measureText(countText).width
+  ctx.fillText(countText, x + width, midY)
+
+  drawHairline(ctx, INK.line, enX + enWidth + 12, midY - 1, x + width - countWidth - 12, midY - 1)
 
   return y + SECTION_HEAD_H
 }
@@ -639,7 +1316,6 @@ function drawSectionHeader(
 /** 画一个网格区，返回下一个可用的 y 坐标 */
 function drawGrid(
   ctx: CanvasRenderingContext2D,
-  theme: ExportTheme,
   cards: readonly ExportCard[],
   images: Map<string, HTMLImageElement | null>,
   columns: number,
@@ -648,7 +1324,7 @@ function drawGrid(
   for (const [index, card] of cards.entries()) {
     const row = Math.floor(index / columns)
     const column = index % columns
-    drawCard(ctx, theme, card, images, PAGE_PAD + column * (CARD_W + GAP), y + row * (CARD_H + GAP))
+    drawCard(ctx, card, images, PAGE_PAD + column * (CARD_W + GAP), y + row * (CARD_H + GAP))
   }
 
   const rows = Math.ceil(cards.length / columns)
@@ -658,13 +1334,12 @@ function drawGrid(
 /**
  * 把宝藏基质卡片渲染成一张 PNG。
  *
- * @param input 卡片数据、标题与主题色。
+ * @param input 卡片数据与页头文案。
  * @returns PNG Blob、预览用 object URL 及实际尺寸。
  * @throws 卡片为空、或画布导出失败时抛出。
  */
 export async function renderMatrixExport(input: MatrixExportInput): Promise<MatrixExportResult> {
   const { weapons, customs } = input
-  const theme = normalizeTheme(input.theme)
   const allCards = [...weapons, ...customs]
   if (allCards.length === 0) {
     throw new Error('没有可导出的条目')
@@ -692,46 +1367,41 @@ export async function renderMatrixExport(input: MatrixExportInput): Promise<Matr
   // 缩放一次之后，下面所有布局数学都按 CSS 像素来写
   ctx.scale(scale, scale)
 
-  ctx.fillStyle = theme.background
-  ctx.fillRect(0, 0, width, height)
-
-  // 页头
-  ctx.fillStyle = theme.onSurface
-  ctx.font = `700 18px ${FONT_STACK}`
-  ctx.textAlign = 'left'
-  ctx.textBaseline = 'middle'
-  ctx.fillText(input.title, PAGE_PAD, PAGE_PAD + 16)
-  ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
-  ctx.font = `400 12px ${FONT_STACK}`
-  ctx.fillText(input.subtitle, PAGE_PAD, PAGE_PAD + 40)
+  drawPaper(ctx, width, height)
 
   const gridWidth = width - PAGE_PAD * 2
+  drawHeader(ctx, input, allCards.length, PAGE_PAD, PAGE_PAD, gridWidth)
+
   let cursorY = PAGE_PAD + HEADER_H
 
   if (weapons.length > 0) {
     cursorY = drawSectionHeader(
       ctx,
-      theme,
-      `内置武器 (${weapons.length})`,
+      '内置武器',
+      'BUILT-IN WEAPONS',
+      weapons.length,
       PAGE_PAD,
       cursorY,
       gridWidth,
     )
-    cursorY = drawGrid(ctx, theme, weapons, images, columns, cursorY)
+    cursorY = drawGrid(ctx, weapons, images, columns, cursorY)
   }
 
   if (customs.length > 0) {
     if (weapons.length > 0) cursorY += SECTION_GAP
     cursorY = drawSectionHeader(
       ctx,
-      theme,
-      `自定义基质 (${customs.length})`,
+      '自定义基质',
+      'CUSTOM MATRICES',
+      customs.length,
       PAGE_PAD,
       cursorY,
       gridWidth,
     )
-    drawGrid(ctx, theme, customs, images, columns, cursorY)
+    cursorY = drawGrid(ctx, customs, images, columns, cursorY)
   }
+
+  drawFooter(ctx, allCards.length, PAGE_PAD, cursorY + SECTION_GAP, gridWidth)
 
   const blob = await canvasToBlob(canvas)
   return {

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -220,6 +220,24 @@ function withAlpha(color: string, alpha: number): string {
 }
 
 /**
+ * 把主题色统一规范成 canvas 一定认得的 rgb 字符串。
+ *
+ * canvas 对无效的 fillStyle 是静默忽略的——一个 undefined 会让文字直接消失，
+ * 而不是报错。这里先过一遍 color 包（它把无效值兜底成黑色），
+ * 让"取色取错了"至少表现为颜色不对，而不是整块内容不翼而飞。
+ */
+function normalizeTheme(theme: ExportTheme): ExportTheme {
+  const toRgb = (color: string) => Color(color).string()
+  return {
+    primary: toRgb(theme.primary),
+    onPrimary: toRgb(theme.onPrimary),
+    background: toRgb(theme.background),
+    surface: toRgb(theme.surface),
+    onSurface: toRgb(theme.onSurface),
+  }
+}
+
+/**
  * 把文字压进指定宽度：先按比例缩字号，到下限仍超宽则尾部截断加省略号。
  *
  * 思路与 utils/autoFontSizing.ts 一致，只是把 DOM 测量换成 measureText。
@@ -580,7 +598,8 @@ function drawGrid(
  * @throws 卡片为空、或画布导出失败时抛出。
  */
 export async function renderMatrixExport(input: MatrixExportInput): Promise<MatrixExportResult> {
-  const { weapons, customs, theme } = input
+  const { weapons, customs } = input
+  const theme = normalizeTheme(input.theme)
   const allCards = [...weapons, ...customs]
   if (allCards.length === 0) {
     throw new Error('没有可导出的条目')

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -1,0 +1,661 @@
+/**
+ * 宝藏基质导出图的 Canvas 绘制模块。
+ *
+ * 这里只负责「把一组卡片画成一张 PNG」，不感知任何应用状态：
+ * 调用方把 profile、静态数据、主题色整理成普通对象传进来。
+ * 这样布局计算能在 node 环境的单测里直接跑，无需 DOM。
+ */
+
+import Color from 'color'
+
+/** 导出图里的一张卡片 */
+export interface ExportCard {
+  /** 'weapon' 画武器 icon + 基质小图；'custom' 只画放大的基质图 */
+  kind: 'weapon' | 'custom'
+  name: string
+  /** 武器 icon 地址；自定义基质没有武器图，传 null */
+  iconUrl: string | null
+  /** 基质底板地址 */
+  essenceBgUrl: string
+  /** 技能属性图标地址 */
+  skillIconUrl: string | null
+  /** 底部色条颜色：内置武器用稀有度色，自定义基质用橙色 */
+  tierColor: string
+  levels: readonly [number, number, number]
+  maxed: boolean
+  /** 扫描到的基质枚数；缺省或非正数时不画角标 */
+  badgeCount?: number
+}
+
+/**
+ * 绘制用的主题色。
+ *
+ * canvas 读不到 `--v-theme-*` 这类 CSS 变量，颜色必须由调用方从
+ * Vuetify 的 `useTheme()` 里取出来显式传入。
+ */
+export interface ExportTheme {
+  primary: string
+  onPrimary: string
+  background: string
+  surface: string
+  onSurface: string
+}
+
+export interface MatrixExportInput {
+  /** 内置武器卡，调用方已排好序 */
+  weapons: readonly ExportCard[]
+  /** 自定义基质卡，永远画在最下方 */
+  customs: readonly ExportCard[]
+  title: string
+  subtitle: string
+  theme: ExportTheme
+  /** 像素倍率，默认 2；超出画布上限时内部自动降级 */
+  scale?: number
+  /** 网格列数，不传则按卡片总数自适应 */
+  columns?: number
+}
+
+export interface MatrixExportResult {
+  blob: Blob
+  /** 预览用的 object URL，调用方负责 revoke */
+  objectUrl: string
+  /** CSS 像素尺寸（非设备像素） */
+  width: number
+  height: number
+  /** 实际生效的倍率，可能因画布上限被降级 */
+  scale: number
+  /** 加载失败、已用占位图代替的图片数量 */
+  missingImages: number
+}
+
+/** 各词条的方格数，与 useWeaponStats 的 AFFIX_MAX_LEVEL 保持一致 */
+const AFFIX_PIP_COUNT = [6, 6, 3] as const
+
+/**
+ * 词条槽位配色。
+ *
+ * 基础属性跟随主题 primary，另外两个沿用 treasure-matrix.vue 里
+ * $attr-teal / $attr-indigo 的字面值，保证导出图与页面观感一致。
+ */
+const ATTR_TEAL = '#48a9a6'
+const ATTR_INDIGO = '#5c6bc0'
+
+/** 满级彩虹环的渐变色，取自 WeaponOverview.vue 的 .rainbow-border */
+const RAINBOW_STOPS = [
+  '#ffffff',
+  '#ff4ada',
+  '#ff4e4e',
+  '#ff9832',
+  '#ffff00',
+  '#00ff00',
+  '#00ffff',
+  '#79a0fd',
+  '#d46eff',
+  '#ff8df0',
+  '#ffffff',
+] as const
+
+/** 自定义基质的主题橙，与 CustomStatIcon.vue 一致 */
+const CUSTOM_ORANGE = '#ff7100'
+
+// --- 布局常量（CSS 像素）---
+const PAGE_PAD = 24
+const GAP = 14
+const SECTION_GAP = 22
+const HEADER_H = 62
+const SECTION_HEAD_H = 30
+const CARD_W = 260
+const CARD_H = 132
+const CARD_R = 8
+const CARD_PAD = 12
+const NAME_H = 22
+const ICON = 76
+const MATRIX_ICON = 56
+const PIP_W = 8
+const PIP_H = 17
+const PIP_GAP = 3
+const PIP_ROW_GAP = 26
+const BADGE_R = 11
+
+/** 画布单边的设备像素上限，取远低于 Chromium 16384 的保守值 */
+const MAX_DEVICE_PX = 8192
+
+const FONT_STACK = '"HarmonyOS Sans SC", sans-serif'
+
+/**
+ * 按卡片总数选择网格列数。
+ *
+ * 两个区共用同一列数，网格才对得齐。
+ */
+export function pickColumns(cardCount: number): number {
+  if (cardCount <= 3) return Math.max(1, cardCount)
+  if (cardCount <= 8) return 3
+  if (cardCount <= 18) return 4
+  if (cardCount <= 40) return 5
+  return 6
+}
+
+/**
+ * 计算画布尺寸与两个区各自的行数。
+ *
+ * 任一区为空时，该区连同区标题都不占高度。
+ */
+export function computeCanvasSize(
+  weaponCount: number,
+  customCount: number,
+  columns: number,
+): { width: number; height: number; weaponRows: number; customRows: number } {
+  const cols = Math.max(1, columns)
+  const weaponRows = Math.ceil(weaponCount / cols)
+  const customRows = Math.ceil(customCount / cols)
+
+  const width = PAGE_PAD * 2 + cols * CARD_W + (cols - 1) * GAP
+
+  let height = PAGE_PAD + HEADER_H
+  if (weaponRows > 0) {
+    height += SECTION_HEAD_H + weaponRows * (CARD_H + GAP) - GAP
+  }
+  if (customRows > 0) {
+    if (weaponRows > 0) height += SECTION_GAP
+    height += SECTION_HEAD_H + customRows * (CARD_H + GAP) - GAP
+  }
+  height += PAGE_PAD
+
+  return { width, height, weaponRows, customRows }
+}
+
+/**
+ * 图片缓存：只缓存加载成功的，失败的下次重试
+ * （浏览器自己会缓存 404，重试成本很低）。
+ */
+const imageCache = new Map<string, HTMLImageElement>()
+
+/** 加载单张图片；失败时返回 null，由调用方画占位图 */
+async function loadImage(url: string): Promise<HTMLImageElement | null> {
+  const cached = imageCache.get(url)
+  if (cached) return cached
+
+  const image = new Image()
+  image.src = url
+  try {
+    // decode() 在 404 或解码失败时 reject，这里统一降级为 null
+    await image.decode()
+  } catch {
+    return null
+  }
+  imageCache.set(url, image)
+  return image
+}
+
+/** 并发预加载所有卡片用到的图片，返回 url -> 图片（失败为 null）的映射 */
+async function preloadImages(
+  cards: readonly ExportCard[],
+): Promise<Map<string, HTMLImageElement | null>> {
+  const urls = new Set<string>()
+  for (const card of cards) {
+    if (card.iconUrl) urls.add(card.iconUrl)
+    if (card.essenceBgUrl) urls.add(card.essenceBgUrl)
+    if (card.skillIconUrl) urls.add(card.skillIconUrl)
+  }
+
+  const entries = await Promise.all(
+    [...urls].map(async (url) => [url, await loadImage(url)] as const),
+  )
+  return new Map(entries)
+}
+
+/** 把 canvas 转成 PNG Blob；toBlob 是回调式的，这里包一层 Promise */
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob)
+      else reject(new Error('画布导出失败'))
+    }, 'image/png')
+  })
+}
+
+/** 以 rgba 形式取主题色的透明度变体 */
+function withAlpha(color: string, alpha: number): string {
+  return Color(color).alpha(alpha).string()
+}
+
+/**
+ * 把文字压进指定宽度：先按比例缩字号，到下限仍超宽则尾部截断加省略号。
+ *
+ * 思路与 utils/autoFontSizing.ts 一致，只是把 DOM 测量换成 measureText。
+ * 返回前会把 ctx.font 留在最终字号上，调用方紧接着 fillText 即可。
+ */
+function fitText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  maxFontSize: number,
+  minFontSize: number,
+  weight = 700,
+): string {
+  ctx.font = `${weight} ${maxFontSize}px ${FONT_STACK}`
+  const fullWidth = ctx.measureText(text).width
+  if (fullWidth <= maxWidth) return text
+
+  const scaled = Math.max((maxFontSize * maxWidth) / fullWidth, minFontSize)
+  ctx.font = `${weight} ${scaled}px ${FONT_STACK}`
+  if (ctx.measureText(text).width <= maxWidth) return text
+
+  // 缩到下限仍放不下，只能截断
+  let truncated = text
+  while (truncated.length > 1 && ctx.measureText(`${truncated}…`).width > maxWidth) {
+    truncated = truncated.slice(0, -1)
+  }
+  return `${truncated}…`
+}
+
+/** 清掉阴影设置。canvas 的 shadow 是全局状态，画完必须复位，否则后续绘制全带影子 */
+function clearShadow(ctx: CanvasRenderingContext2D): void {
+  ctx.shadowColor = 'transparent'
+  ctx.shadowBlur = 0
+  ctx.shadowOffsetX = 0
+  ctx.shadowOffsetY = 0
+}
+
+/** 按 object-fit: cover 的规则把图片画进目标矩形 */
+function drawImageCover(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  const scale = Math.max(width / image.naturalWidth, height / image.naturalHeight)
+  const drawW = image.naturalWidth * scale
+  const drawH = image.naturalHeight * scale
+  ctx.drawImage(image, x + (width - drawW) / 2, y + (height - drawH) / 2, drawW, drawH)
+}
+
+/** 图片缺失时的占位块 */
+function drawImagePlaceholder(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  ctx.fillStyle = withAlpha(theme.onSurface, 0.08)
+  ctx.beginPath()
+  ctx.roundRect(x, y, size, size, 6)
+  ctx.fill()
+
+  ctx.fillStyle = withAlpha(theme.onSurface, 0.35)
+  ctx.font = `700 ${Math.round(size * 0.32)}px ${FONT_STACK}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText('?', x + size / 2, y + size / 2)
+}
+
+/**
+ * 画武器 icon：图片 + 底部稀有度渐变 + 底部色条。
+ *
+ * 对应 ItemIcon.vue 的三层结构，但不画 icon 内嵌名称——
+ * 76px 见方塞中文名不可读，名称在卡片里有独立一行。
+ */
+function drawWeaponIcon(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  image: HTMLImageElement | null,
+  card: ExportCard,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  if (!image) {
+    drawImagePlaceholder(ctx, theme, x, y, size)
+    return
+  }
+
+  ctx.save()
+  ctx.beginPath()
+  ctx.roundRect(x, y, size, size, 6)
+  ctx.clip()
+
+  drawImageCover(ctx, image, x, y, size, size)
+
+  // 底部 70%→100% 的稀有度色渐变
+  const gradient = ctx.createLinearGradient(x, y, x, y + size)
+  gradient.addColorStop(0.7, withAlpha(card.tierColor, 0))
+  gradient.addColorStop(1, withAlpha(card.tierColor, 0.3))
+  ctx.fillStyle = gradient
+  ctx.fillRect(x, y, size, size)
+
+  // 底部 4% 高的稀有度色条
+  const barHeight = Math.max(2, size * 0.04)
+  ctx.fillStyle = card.tierColor
+  ctx.fillRect(x, y + size - barHeight, size, barHeight)
+
+  ctx.restore()
+}
+
+/**
+ * 画基质图：底板 + 技能图标 + 橙色渐变 + 底部橙条 + 橙色描边。
+ *
+ * 对应 CustomStatIcon.vue 的层叠结构，技能图标沿用 translate(5%, -5%) 的偏移。
+ */
+function drawEssenceIcon(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  bgImage: HTMLImageElement | null,
+  skillImage: HTMLImageElement | null,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  if (!bgImage && !skillImage) {
+    drawImagePlaceholder(ctx, theme, x, y, size)
+    return
+  }
+
+  ctx.save()
+  ctx.beginPath()
+  ctx.roundRect(x, y, size, size, [6, 6, 0, 0])
+  ctx.clip()
+
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(x, y, size, size)
+  if (bgImage) drawImageCover(ctx, bgImage, x, y, size, size)
+  if (skillImage) {
+    drawImageCover(ctx, skillImage, x + size * 0.05, y - size * 0.05, size, size)
+  }
+
+  const gradient = ctx.createLinearGradient(x, y, x, y + size)
+  gradient.addColorStop(0.7, withAlpha(CUSTOM_ORANGE, 0))
+  gradient.addColorStop(1, withAlpha(CUSTOM_ORANGE, 0.3))
+  ctx.fillStyle = gradient
+  ctx.fillRect(x, y, size, size)
+
+  const barHeight = Math.max(2, size * 0.04)
+  ctx.fillStyle = CUSTOM_ORANGE
+  ctx.fillRect(x, y + size - barHeight, size, barHeight)
+
+  ctx.restore()
+
+  ctx.strokeStyle = withAlpha(CUSTOM_ORANGE, 0.5)
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.roundRect(x + 1, y + 1, size - 2, size - 2, [6, 6, 0, 0])
+  ctx.stroke()
+}
+
+/** 画一行方格能量条，对应 treasure-matrix.vue 的 .attr-pips */
+function drawPipRow(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  level: number,
+  pipCount: number,
+  activeColor: string,
+  x: number,
+  y: number,
+): void {
+  for (let index = 0; index < pipCount; index++) {
+    const pipX = x + index * (PIP_W + PIP_GAP)
+    const active = index < level
+
+    if (active) {
+      ctx.shadowColor = withAlpha(activeColor, 0.32)
+      ctx.shadowBlur = 7
+      ctx.shadowOffsetY = 2
+      ctx.fillStyle = activeColor
+    } else {
+      ctx.fillStyle = withAlpha(theme.onSurface, 0.12)
+    }
+
+    ctx.beginPath()
+    ctx.roundRect(pipX, y, PIP_W, PIP_H, 4)
+    ctx.fill()
+    clearShadow(ctx)
+  }
+
+  ctx.fillStyle = withAlpha(theme.onSurface, 0.68)
+  ctx.font = `800 10px ${FONT_STACK}`
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(`${level}/${pipCount}`, x + pipCount * (PIP_W + PIP_GAP) + 4, y + PIP_H / 2)
+}
+
+/** 满级卡片的彩虹外框，取 WeaponOverview.vue 彩虹环渐变的一帧 */
+function drawRainbowBorder(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  // 45° 方向：从左下到右上
+  const gradient = ctx.createLinearGradient(x, y + height, x + width, y)
+  for (const [index, color] of RAINBOW_STOPS.entries()) {
+    gradient.addColorStop(index / (RAINBOW_STOPS.length - 1), color)
+  }
+
+  ctx.strokeStyle = gradient
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.roundRect(x + 1, y + 1, width - 2, height - 2, CARD_R)
+  ctx.stroke()
+}
+
+/** 扫描数量角标，对应设置页 v-badge 的右上角圆形数字 */
+function drawBadge(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  count: number,
+  centerX: number,
+  centerY: number,
+): void {
+  ctx.fillStyle = theme.primary
+  ctx.beginPath()
+  ctx.arc(centerX, centerY, BADGE_R, 0, Math.PI * 2)
+  ctx.fill()
+
+  ctx.fillStyle = theme.onPrimary
+  ctx.font = `700 11px ${FONT_STACK}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(count > 99 ? '99+' : String(count), centerX, centerY)
+}
+
+/** 画一整张卡片 */
+function drawCard(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  card: ExportCard,
+  images: Map<string, HTMLImageElement | null>,
+  x: number,
+  y: number,
+): void {
+  ctx.fillStyle = theme.surface
+  ctx.beginPath()
+  ctx.roundRect(x, y, CARD_W, CARD_H, CARD_R)
+  ctx.fill()
+  ctx.strokeStyle = withAlpha(theme.onSurface, 0.12)
+  ctx.lineWidth = 1
+  ctx.stroke()
+
+  // 名称行
+  const nameMaxWidth = CARD_W - CARD_PAD * 2
+  const nameText = fitText(ctx, card.name, nameMaxWidth, 14, 10)
+  ctx.fillStyle = theme.onSurface
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(nameText, x + CARD_W / 2, y + CARD_PAD + NAME_H / 2)
+
+  const bodyY = y + CARD_PAD + NAME_H + 4
+  const iconImage = card.iconUrl ? (images.get(card.iconUrl) ?? null) : null
+  const bgImage = card.essenceBgUrl ? (images.get(card.essenceBgUrl) ?? null) : null
+  const skillImage = card.skillIconUrl ? (images.get(card.skillIconUrl) ?? null) : null
+
+  let pipX: number
+  if (card.kind === 'weapon') {
+    const iconX = x + CARD_PAD
+    drawWeaponIcon(ctx, theme, iconImage, card, iconX, bodyY, ICON)
+
+    const essenceX = iconX + ICON + 10
+    const essenceY = bodyY + (ICON - MATRIX_ICON) / 2
+    drawEssenceIcon(ctx, theme, bgImage, skillImage, essenceX, essenceY, MATRIX_ICON)
+    pipX = essenceX + MATRIX_ICON + 12
+
+    if (card.badgeCount && card.badgeCount > 0) {
+      drawBadge(ctx, theme, card.badgeCount, iconX + ICON, bodyY)
+    }
+  } else {
+    // 自定义基质没有武器图，基质图放大占据 icon 的位置
+    const essenceX = x + CARD_PAD
+    drawEssenceIcon(ctx, theme, bgImage, skillImage, essenceX, bodyY, ICON)
+    pipX = essenceX + ICON + 12
+  }
+
+  // 三行方格能量条
+  const pipColors = [theme.primary, ATTR_TEAL, ATTR_INDIGO]
+  for (let slot = 0; slot < 3; slot++) {
+    drawPipRow(
+      ctx,
+      theme,
+      card.levels[slot] ?? 0,
+      AFFIX_PIP_COUNT[slot]!,
+      pipColors[slot]!,
+      pipX,
+      bodyY + slot * PIP_ROW_GAP,
+    )
+  }
+
+  if (card.maxed) drawRainbowBorder(ctx, x, y, CARD_W, CARD_H)
+}
+
+/** 画区标题，返回下一个可用的 y 坐标 */
+function drawSectionHeader(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  text: string,
+  x: number,
+  y: number,
+  width: number,
+): number {
+  ctx.fillStyle = withAlpha(theme.onSurface, 0.62)
+  ctx.font = `700 14px ${FONT_STACK}`
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, x, y + SECTION_HEAD_H / 2)
+
+  ctx.strokeStyle = withAlpha(theme.onSurface, 0.12)
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(x + ctx.measureText(text).width + 12, y + SECTION_HEAD_H / 2)
+  ctx.lineTo(x + width, y + SECTION_HEAD_H / 2)
+  ctx.stroke()
+
+  return y + SECTION_HEAD_H
+}
+
+/** 画一个网格区，返回下一个可用的 y 坐标 */
+function drawGrid(
+  ctx: CanvasRenderingContext2D,
+  theme: ExportTheme,
+  cards: readonly ExportCard[],
+  images: Map<string, HTMLImageElement | null>,
+  columns: number,
+  y: number,
+): number {
+  for (const [index, card] of cards.entries()) {
+    const row = Math.floor(index / columns)
+    const column = index % columns
+    drawCard(ctx, theme, card, images, PAGE_PAD + column * (CARD_W + GAP), y + row * (CARD_H + GAP))
+  }
+
+  const rows = Math.ceil(cards.length / columns)
+  return y + rows * (CARD_H + GAP) - GAP
+}
+
+/**
+ * 把宝藏基质卡片渲染成一张 PNG。
+ *
+ * @param input 卡片数据、标题与主题色。
+ * @returns PNG Blob、预览用 object URL 及实际尺寸。
+ * @throws 卡片为空、或画布导出失败时抛出。
+ */
+export async function renderMatrixExport(input: MatrixExportInput): Promise<MatrixExportResult> {
+  const { weapons, customs, theme } = input
+  const allCards = [...weapons, ...customs]
+  if (allCards.length === 0) {
+    throw new Error('没有可导出的条目')
+  }
+
+  const columns = input.columns ?? pickColumns(allCards.length)
+  const { width, height } = computeCanvasSize(weapons.length, customs.length, columns)
+
+  const images = await preloadImages(allCards)
+  let missingImages = 0
+  for (const image of images.values()) {
+    if (!image) missingImages++
+  }
+
+  // 固定倍率而非跟随 devicePixelRatio：同一份数据在任何机器上都应产出同样的图
+  const requestedScale = input.scale ?? 2
+  const scale = Math.max(1, Math.min(requestedScale, MAX_DEVICE_PX / Math.max(width, height)))
+
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.round(width * scale)
+  canvas.height = Math.round(height * scale)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('无法创建画布上下文')
+
+  // 缩放一次之后，下面所有布局数学都按 CSS 像素来写
+  ctx.scale(scale, scale)
+
+  ctx.fillStyle = theme.background
+  ctx.fillRect(0, 0, width, height)
+
+  // 页头
+  ctx.fillStyle = theme.onSurface
+  ctx.font = `700 18px ${FONT_STACK}`
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(input.title, PAGE_PAD, PAGE_PAD + 16)
+  ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
+  ctx.font = `400 12px ${FONT_STACK}`
+  ctx.fillText(input.subtitle, PAGE_PAD, PAGE_PAD + 40)
+
+  const gridWidth = width - PAGE_PAD * 2
+  let cursorY = PAGE_PAD + HEADER_H
+
+  if (weapons.length > 0) {
+    cursorY = drawSectionHeader(
+      ctx,
+      theme,
+      `内置武器 (${weapons.length})`,
+      PAGE_PAD,
+      cursorY,
+      gridWidth,
+    )
+    cursorY = drawGrid(ctx, theme, weapons, images, columns, cursorY)
+  }
+
+  if (customs.length > 0) {
+    if (weapons.length > 0) cursorY += SECTION_GAP
+    cursorY = drawSectionHeader(
+      ctx,
+      theme,
+      `自定义基质 (${customs.length})`,
+      PAGE_PAD,
+      cursorY,
+      gridWidth,
+    )
+    drawGrid(ctx, theme, customs, images, columns, cursorY)
+  }
+
+  const blob = await canvasToBlob(canvas)
+  return {
+    blob,
+    objectUrl: URL.createObjectURL(blob),
+    width,
+    height,
+    scale,
+    missingImages,
+  }
+}

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -13,6 +13,8 @@ export interface ExportCard {
   /** 'weapon' 画武器 icon + 基质小图；'custom' 只画放大的基质图 */
   kind: 'weapon' | 'custom'
   name: string
+  /** 名称上方的小号注音行（内置武器放 ★ 星级）；缺省则该行留空 */
+  nameRuby?: string
   /** 武器 icon 地址；自定义基质没有武器图，传 null */
   iconUrl: string | null
   /** 基质底板地址 */
@@ -27,6 +29,8 @@ export interface ExportCard {
   badgeCount?: number
   /** 三词条中文名，如 ["攻击", "终结技充能效率", "巧技"] */
   traitNames?: string[]
+  /** 未获得的条目：整张卡片降透明度 + 去色绘制 */
+  dimmed?: boolean
 }
 
 /**
@@ -107,10 +111,13 @@ const SECTION_GAP = 22
 const HEADER_H = 62
 const SECTION_HEAD_H = 30
 const CARD_W = 260
-const CARD_H = 132
+const CARD_H = 144
 const CARD_R = 3
 const CARD_PAD = 12
 const NAME_H = 22
+/** 名称上方的注音行高度；不管有没有星级都占位，两类卡片的名称才对得齐 */
+const RUBY_H = 11
+const RUBY_FONTSIZE = 9
 const ICON = 56
 const MATRIX_ICON = 56
 const PIP_W = 8
@@ -119,6 +126,15 @@ const PIP_GAP = 3
 const PIP_ROW_GAP = 21
 const BADGE_R = 11
 const TRAIT_FONTSIZE = 12
+
+/**
+ * 未获得条目的置灰参数，对应总览页 `.weapon-not-owned` 的 `opacity/filter`。
+ *
+ * 透明度比页面上的 0.4 略高：页面只灰化图标，导出图整张卡片一起灰，
+ * 名称和词条名再压到 0.4 就基本读不出来了。
+ */
+const DIMMED_ALPHA = 0.45
+const DIMMED_FILTER = 'grayscale(0.8)'
 
 /** 画布单边的设备像素上限，取远低于 Chromium 16384 的保守值 */
 const MAX_DEVICE_PX = 8192
@@ -505,6 +521,14 @@ function drawCard(
   x: number,
   y: number,
 ): void {
+  // 无条件成对 save/restore：置灰只作用于当前这张卡，
+  // 漏掉 restore 会让后面所有卡片跟着变灰。
+  ctx.save()
+  if (card.dimmed) {
+    ctx.globalAlpha = DIMMED_ALPHA
+    ctx.filter = DIMMED_FILTER
+  }
+
   ctx.fillStyle = theme.surface
   ctx.beginPath()
   ctx.roundRect(x, y, CARD_W, CARD_H, CARD_R)
@@ -515,13 +539,23 @@ function drawCard(
 
   // 名称行
   const nameMaxWidth = CARD_W - CARD_PAD * 2
+
+  // 注音行：星级压到名称上方一行，小一号且半透明，不与名称抢视线
+  if (card.nameRuby) {
+    const rubyText = fitText(ctx, card.nameRuby, nameMaxWidth, RUBY_FONTSIZE, 7)
+    ctx.fillStyle = withAlpha(theme.onSurface, 0.55)
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(rubyText, x + CARD_W / 2, y + CARD_PAD + RUBY_H / 2)
+  }
+
   const nameText = fitText(ctx, card.name, nameMaxWidth, 14, 10)
   ctx.fillStyle = theme.onSurface
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
-  ctx.fillText(nameText, x + CARD_W / 2, y + CARD_PAD + NAME_H / 2)
+  ctx.fillText(nameText, x + CARD_W / 2, y + CARD_PAD + RUBY_H + NAME_H / 2)
 
-  const bodyY = y + CARD_PAD + NAME_H + 4
+  const bodyY = y + CARD_PAD + RUBY_H + NAME_H + 4
   const iconImage = card.iconUrl ? (images.get(card.iconUrl) ?? null) : null
   const bgImage = card.essenceBgUrl ? (images.get(card.essenceBgUrl) ?? null) : null
   const skillImage = card.skillIconUrl ? (images.get(card.skillIconUrl) ?? null) : null
@@ -573,6 +607,8 @@ function drawCard(
   }
 
   if (card.maxed) drawRainbowBorder(ctx, x, y, CARD_W, CARD_H)
+
+  ctx.restore()
 }
 
 /** 画区标题，返回下一个可用的 y 坐标 */

--- a/frontend/src/utils/matrixExport.ts
+++ b/frontend/src/utils/matrixExport.ts
@@ -1,7 +1,7 @@
 /**
  * 宝藏基质导出图的 Canvas 绘制模块。
  *
- * 这里只负责「把一组卡片画成一张 PNG」，不感知任何应用状态：
+ * 这里只负责「把一组卡片画成一张图」，不感知任何应用状态：
  * 调用方把 profile、静态数据整理成普通对象传进来。
  * 这样布局计算能在 node 环境的单测里直接跑，无需 DOM。
  *
@@ -53,6 +53,7 @@ export interface MatrixExportInput {
 }
 
 export interface MatrixExportResult {
+  /** 导出图；正常是 WebP，浏览器不支持 WebP 编码时会回退成 PNG，看 blob.type */
   blob: Blob
   /** 预览用的 object URL，调用方负责 revoke */
   objectUrl: string
@@ -219,6 +220,23 @@ const GRID_STEP = 44
 const MAX_DEVICE_PX = 8192
 
 /**
+ * 导出图的编码格式。
+ *
+ * PNG 对这张图格外不利：drawPaper 铺的颗粒层逐像素随机，几乎不可压缩，
+ * 两千万像素能压出十几 MB。同一份内容换成 WebP 只有几 MB。
+ */
+const EXPORT_MIME = 'image/webp'
+
+/**
+ * WebP 质量。
+ *
+ * Chromium 只在质量严格等于 1 时走无损编码，小于 1 则是有损档位——有损能再
+ * 小一个量级，代价是颗粒层被平滑掉一部分。想换档位只改这个常量，其余链路
+ * 都按实际产出的 MIME 走，不必跟着动。
+ */
+const EXPORT_QUALITY = 1
+
+/**
  * 按卡片总数选择网格列数。
  *
  * 两个区共用同一列数，网格才对得齐。
@@ -313,14 +331,56 @@ async function preloadImages(
   return new Map(entries)
 }
 
-/** 把 canvas 转成 PNG Blob；toBlob 是回调式的，这里包一层 Promise */
-function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+/**
+ * 把 canvas 编码成 Blob；toBlob 是回调式的，这里包一层 Promise。
+ *
+ * 浏览器不认识请求的格式时，toBlob 会静默回退成 PNG 而不是报错，所以调用方
+ * 得看 blob.type，不能假定拿到的就是自己要的格式。
+ */
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  mimeType: string,
+  quality?: number,
+): Promise<Blob> {
   return new Promise((resolve, reject) => {
-    canvas.toBlob((blob) => {
-      if (blob) resolve(blob)
-      else reject(new Error('画布导出失败'))
-    }, 'image/png')
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob)
+        else reject(new Error('画布导出失败'))
+      },
+      mimeType,
+      quality,
+    )
   })
+}
+
+/**
+ * 把导出图重新编码成 PNG。
+ *
+ * 剪贴板专用：Chromium 的剪贴板写入只接受 image/png，塞 WebP 会抛
+ * NotAllowedError。这里从已有的 Blob 解码重画，而不是让 renderMatrixExport
+ * 一次产出两份——编码这么大的图要几百毫秒，筛选项每动一次都要重绘，
+ * 不该为一个可能不会被点的按钮每次都付这个代价。
+ *
+ * @param blob 导出图 Blob；已经是 PNG 时原样返回。
+ * @returns PNG 格式的 Blob。
+ * @throws 解码失败或画布导出失败时抛出。
+ */
+export async function toPngBlob(blob: Blob): Promise<Blob> {
+  if (blob.type === 'image/png') return blob
+
+  const bitmap = await createImageBitmap(blob)
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('无法创建画布上下文')
+    ctx.drawImage(bitmap, 0, 0)
+    return await canvasToBlob(canvas, 'image/png')
+  } finally {
+    bitmap.close()
+  }
 }
 
 /** 以 rgba 形式取颜色的透明度变体 */
@@ -1332,10 +1392,10 @@ function drawGrid(
 }
 
 /**
- * 把宝藏基质卡片渲染成一张 PNG。
+ * 把宝藏基质卡片渲染成一张导出图。
  *
  * @param input 卡片数据与页头文案。
- * @returns PNG Blob、预览用 object URL 及实际尺寸。
+ * @returns 导出图 Blob（WebP，不支持时回退 PNG）、预览用 object URL 及实际尺寸。
  * @throws 卡片为空、或画布导出失败时抛出。
  */
 export async function renderMatrixExport(input: MatrixExportInput): Promise<MatrixExportResult> {
@@ -1403,7 +1463,7 @@ export async function renderMatrixExport(input: MatrixExportInput): Promise<Matr
 
   drawFooter(ctx, allCards.length, PAGE_PAD, cursorY + SECTION_GAP, gridWidth)
 
-  const blob = await canvasToBlob(canvas)
+  const blob = await canvasToBlob(canvas, EXPORT_MIME, EXPORT_QUALITY)
   return {
     blob,
     objectUrl: URL.createObjectURL(blob),

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -26,6 +26,7 @@ PROTECTED_PATHS: list[str] = [
     "profiles.json",
     "logs/",
     "screenshots/",
+    "exports/",
     ".env",
 ]
 

--- a/src/endfield_essence_recognizer/api/router.py
+++ b/src/endfield_essence_recognizer/api/router.py
@@ -1,10 +1,20 @@
 from fastapi import APIRouter
 
-from .routes import config, profiles, scanner, screenshot, static_data, system, update
+from .routes import (
+    config,
+    matrix_export,
+    profiles,
+    scanner,
+    screenshot,
+    static_data,
+    system,
+    update,
+)
 from .websockets import events, logs, update_progress
 
 api_router = APIRouter(prefix="/api")
 api_router.include_router(config.router)
+api_router.include_router(matrix_export.router)
 api_router.include_router(profiles.router)
 api_router.include_router(scanner.router)
 api_router.include_router(screenshot.router)

--- a/src/endfield_essence_recognizer/api/routes/matrix_export.py
+++ b/src/endfield_essence_recognizer/api/routes/matrix_export.py
@@ -1,7 +1,7 @@
 """
 宝藏基质导出 API 路由。
 
-接收前端 Canvas 渲染出的 PNG 图片，落盘到导出目录，并可选地打开所在文件夹。
+接收前端 Canvas 渲染出的图片，落盘到导出目录，并可选地打开所在文件夹。
 """
 
 import asyncio
@@ -26,14 +26,41 @@ from endfield_essence_recognizer.utils.log import logger
 
 router = APIRouter(prefix="/export", tags=["export"])
 
-# PNG 文件头魔数。这个接口只接受本工具自己画出来的 PNG，不做通用文件落盘。
+# 这个接口只接受本工具自己画出来的图，不做通用文件落盘。
+# WebP 是 RIFF 容器：前 4 字节 'RIFF'、4 字节长度、再 4 字节 'WEBP'。
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_RIFF_SIGNATURE = b"RIFF"
+_WEBP_SIGNATURE = b"WEBP"
 
 # 导出图体积上限。前端 2x 缩放下的实际产物远小于此值，这里只作兜底防御。
 _MAX_EXPORT_BYTES = 32 * 1024 * 1024
 
 # Windows 文件名非法字符与控制字符
 _ILLEGAL_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\x00-\x1f]')
+
+
+def _resolve_extension(raw: bytes) -> str:
+    """
+    按图片魔数确定文件扩展名。
+
+    前端主路径产出 WebP；浏览器不支持 WebP 编码时 canvas.toBlob 会静默回退成
+    PNG，两种都要能落盘，否则那种环境下保存会整条失败。扩展名取自实际内容
+    而不是前端声明，落盘文件的后缀就一定和内容对得上。
+
+    Args:
+        raw: 解码后的图片字节。
+
+    Returns:
+        不含点号的扩展名。
+
+    Raises:
+        ValueError: 内容既不是 WebP 也不是 PNG。
+    """
+    if raw[:4] == _RIFF_SIGNATURE and raw[8:12] == _WEBP_SIGNATURE:
+        return "webp"
+    if raw.startswith(_PNG_SIGNATURE):
+        return "png"
+    raise ValueError("图片内容不是合法的 WebP 或 PNG")
 
 
 def _safe_file_stem(profile_name: str) -> str:
@@ -77,15 +104,14 @@ async def export_treasure_matrix(
     exports_dir: Path = Depends(get_exports_dir_dep),
     manager: ProfileManager = Depends(get_profile_manager),
 ) -> TreasureMatrixExportResponse:
-    """接收前端渲染好的 PNG 图片并落盘，可选地打开所在文件夹。"""
+    """接收前端渲染好的图片并落盘，可选地打开所在文件夹。"""
     try:
         try:
             raw = base64.b64decode(request.image_base64, validate=True)
         except (binascii.Error, ValueError) as e:
             raise ValueError("图片内容不是合法的 base64") from e
 
-        if not raw.startswith(_PNG_SIGNATURE):
-            raise ValueError("图片内容不是合法的 PNG")
+        extension = _resolve_extension(raw)
 
         if len(raw) > _MAX_EXPORT_BYTES:
             raise ValueError(f"图片体积超过上限（{len(raw) / 1024 / 1024:.1f} MB）")
@@ -93,7 +119,7 @@ async def export_treasure_matrix(
         # 文件名完全由后端拼接：账号名清洗后加时间戳，多次导出天然不覆盖，
         # 前端不参与命名，杜绝路径穿越。
         stem = _safe_file_stem(manager.get_active_profile_name())
-        file_name = f"{stem}_{datetime.now():%Y%m%d-%H%M%S}.png"
+        file_name = f"{stem}_{datetime.now():%Y%m%d-%H%M%S}.{extension}"
         save_path = exports_dir / file_name
         await asyncio.to_thread(exports_dir.mkdir, parents=True, exist_ok=True)
         await asyncio.to_thread(save_path.write_bytes, raw)

--- a/src/endfield_essence_recognizer/api/routes/matrix_export.py
+++ b/src/endfield_essence_recognizer/api/routes/matrix_export.py
@@ -1,0 +1,124 @@
+"""
+宝藏基质导出 API 路由。
+
+接收前端 Canvas 渲染出的 PNG 图片，落盘到导出目录，并可选地打开所在文件夹。
+"""
+
+import asyncio
+import base64
+import binascii
+import os
+import platform
+import re
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+
+from endfield_essence_recognizer.api.routes.profiles import get_profile_manager
+from endfield_essence_recognizer.dependencies import get_exports_dir_dep
+from endfield_essence_recognizer.schemas.matrix_export import (
+    TreasureMatrixExportRequest,
+    TreasureMatrixExportResponse,
+)
+from endfield_essence_recognizer.services.profile_manager import ProfileManager
+from endfield_essence_recognizer.utils.log import logger
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+# PNG 文件头魔数。这个接口只接受本工具自己画出来的 PNG，不做通用文件落盘。
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+# 导出图体积上限。前端 2x 缩放下的实际产物远小于此值，这里只作兜底防御。
+_MAX_EXPORT_BYTES = 32 * 1024 * 1024
+
+# Windows 文件名非法字符与控制字符
+_ILLEGAL_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\x00-\x1f]')
+
+
+def _safe_file_stem(profile_name: str) -> str:
+    """
+    把账号名压成可安全用作文件名的片段。
+
+    账号名允许中文和空格，但可能含有路径分隔符或 Windows 非法字符；
+    这里统一替换成下划线并截断，避免写到导出目录之外。
+
+    Args:
+        profile_name: 当前激活的账号名称。
+
+    Returns:
+        清洗后的文件名主干；账号名清洗后为空时回退为固定值。
+    """
+    cleaned = _ILLEGAL_FILENAME_CHARS.sub("_", profile_name).strip(" .")
+    return cleaned[:32] or "treasure_matrix"
+
+
+async def _open_directory(directory: Path) -> None:
+    """
+    在系统文件管理器中打开指定目录。
+
+    Args:
+        directory: 需要打开的目录。
+    """
+    if platform.system() == "Windows":  # Windows
+        os.startfile(directory)
+    elif platform.system() == "Darwin":  # macOS
+        await asyncio.create_subprocess_exec("open", str(directory))
+    else:  # Linux and others
+        await asyncio.create_subprocess_exec("xdg-open", str(directory))
+
+
+@router.post(
+    "/treasure_matrix",
+    description="保存宝藏基质导出图片到本地，返回文件路径和文件名",
+)
+async def export_treasure_matrix(
+    request: TreasureMatrixExportRequest,
+    exports_dir: Path = Depends(get_exports_dir_dep),
+    manager: ProfileManager = Depends(get_profile_manager),
+) -> TreasureMatrixExportResponse:
+    """接收前端渲染好的 PNG 图片并落盘，可选地打开所在文件夹。"""
+    try:
+        try:
+            raw = base64.b64decode(request.image_base64, validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise ValueError("图片内容不是合法的 base64") from e
+
+        if not raw.startswith(_PNG_SIGNATURE):
+            raise ValueError("图片内容不是合法的 PNG")
+
+        if len(raw) > _MAX_EXPORT_BYTES:
+            raise ValueError(f"图片体积超过上限（{len(raw) / 1024 / 1024:.1f} MB）")
+
+        # 文件名完全由后端拼接：账号名清洗后加时间戳，多次导出天然不覆盖，
+        # 前端不参与命名，杜绝路径穿越。
+        stem = _safe_file_stem(manager.get_active_profile_name())
+        file_name = f"{stem}_{datetime.now():%Y%m%d-%H%M%S}.png"
+        save_path = exports_dir / file_name
+        await asyncio.to_thread(exports_dir.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(save_path.write_bytes, raw)
+        logger.info(f"已保存宝藏基质导出图片：{save_path}")
+
+        message = "导出图片已保存。"
+        if request.open_folder:
+            # 打开文件夹失败不能把"已经落盘成功"报成失败，降级成提示即可
+            try:
+                await _open_directory(exports_dir)
+            except Exception as e:
+                logger.exception(f"打开导出目录时出错：{e}")
+                message = f"导出图片已保存，但打开文件夹失败：{e}"
+
+        return TreasureMatrixExportResponse(
+            success=True,
+            message=message,
+            file_path=str(save_path),
+            file_name=file_name,
+        )
+    except Exception as e:
+        logger.exception(f"保存宝藏基质导出图片失败：{e}")
+        return TreasureMatrixExportResponse(
+            success=False,
+            message=str(e),
+            file_path=None,
+            file_name=None,
+        )

--- a/src/endfield_essence_recognizer/core/path.py
+++ b/src/endfield_essence_recognizer/core/path.py
@@ -34,3 +34,8 @@ def get_logs_dir() -> Path:
 def get_screenshots_dir() -> Path:
     """Get the path to the screenshots directory in the root directory."""
     return get_root_dir() / "screenshots"
+
+
+def get_exports_dir() -> Path:
+    """Get the path to the exports directory in the root directory."""
+    return get_root_dir() / "exports"

--- a/src/endfield_essence_recognizer/dependencies/__init__.py
+++ b/src/endfield_essence_recognizer/dependencies/__init__.py
@@ -6,7 +6,7 @@ from .core import (
     get_scanner_context_dep,
     get_scanner_engine_dep,
 )
-from .paths import get_config_path_dep, get_screenshots_dir_dep
+from .paths import get_config_path_dep, get_exports_dir_dep, get_screenshots_dir_dep
 from .recognition import (
     get_abandon_status_recognizer_dep,
     get_attribute_level_recognizer_dep,
@@ -49,6 +49,7 @@ __all__ = [
     "get_delivery_job_reward_recognizer_dep",
     "get_delivery_scene_recognizer_dep",
     "get_event_service",
+    "get_exports_dir_dep",
     "get_game_window_manager",
     "get_lock_status_recognizer_dep",
     "get_log_service",

--- a/src/endfield_essence_recognizer/dependencies/paths.py
+++ b/src/endfield_essence_recognizer/dependencies/paths.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from endfield_essence_recognizer.core.path import get_config_path, get_screenshots_dir
+from endfield_essence_recognizer.core.path import (
+    get_config_path,
+    get_exports_dir,
+    get_screenshots_dir,
+)
 
 
 def get_config_path_dep() -> Path:
@@ -15,3 +19,10 @@ def get_screenshots_dir_dep() -> Path:
     The dependency to get the screenshots directory path.
     """
     return get_screenshots_dir()
+
+
+def get_exports_dir_dep() -> Path:
+    """
+    The dependency to get the exports directory path.
+    """
+    return get_exports_dir()

--- a/src/endfield_essence_recognizer/schemas/matrix_export.py
+++ b/src/endfield_essence_recognizer/schemas/matrix_export.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 
 class TreasureMatrixExportRequest(BaseModel):
     image_base64: str = Field(
-        description="PNG 图片内容的 base64 编码（不含 data URI 前缀）",
+        description="WebP 或 PNG 图片内容的 base64 编码（不含 data URI 前缀）",
     )
     open_folder: bool = Field(
         default=True,

--- a/src/endfield_essence_recognizer/schemas/matrix_export.py
+++ b/src/endfield_essence_recognizer/schemas/matrix_export.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+
+class TreasureMatrixExportRequest(BaseModel):
+    image_base64: str = Field(
+        description="PNG 图片内容的 base64 编码（不含 data URI 前缀）",
+    )
+    open_folder: bool = Field(
+        default=True,
+        description="保存成功后是否打开图片所在的文件夹",
+    )
+
+
+class TreasureMatrixExportResponse(BaseModel):
+    success: bool
+    message: str
+    file_path: str | None = Field(
+        default=None,
+        description="保存的导出图片的完整路径",
+    )
+    file_name: str | None = Field(
+        default=None,
+        description="保存的导出图片文件名",
+    )

--- a/tests/integration/test_matrix_export_api.py
+++ b/tests/integration/test_matrix_export_api.py
@@ -1,0 +1,145 @@
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from endfield_essence_recognizer.api.routes.profiles import get_profile_manager
+from endfield_essence_recognizer.dependencies import get_exports_dir_dep
+from endfield_essence_recognizer.server import app
+
+# 1x1 透明 PNG，仅用于验证落盘链路
+PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA"
+    "60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def mock_profile_manager():
+    manager = MagicMock()
+    manager.get_active_profile_name.return_value = "default"
+    return manager
+
+
+@pytest.fixture
+def client(mock_profile_manager, tmp_path):
+    app.dependency_overrides[get_exports_dir_dep] = lambda: tmp_path / "exports"
+    app.dependency_overrides[get_profile_manager] = lambda: mock_profile_manager
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_open_directory():
+    """拦截打开文件夹，避免测试时真的弹出资源管理器。"""
+    with patch(
+        "endfield_essence_recognizer.api.routes.matrix_export._open_directory"
+    ) as mock:
+        yield mock
+
+
+def test_export_saves_png(client, mock_open_directory, tmp_path):
+    """合法 PNG 应落盘到导出目录，并返回文件路径。"""
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": PNG_BASE64, "open_folder": False},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["file_name"].startswith("default_")
+    assert data["file_name"].endswith(".png")
+
+    saved = tmp_path / "exports" / data["file_name"]
+    assert saved.exists()
+    assert saved.read_bytes() == base64.b64decode(PNG_BASE64)
+
+
+def test_export_rejects_non_png(client, mock_open_directory):
+    """非 PNG 内容必须被拒绝，这个接口不做通用文件落盘。"""
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={
+            "image_base64": base64.b64encode(b"not a png at all").decode(),
+            "open_folder": False,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert "PNG" in data["message"]
+    assert data["file_path"] is None
+
+
+def test_export_rejects_invalid_base64(client, mock_open_directory):
+    """非法 base64 应报错而不是抛出未捕获异常。"""
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": "!!!not base64!!!", "open_folder": False},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert "base64" in data["message"]
+
+
+def test_export_sanitizes_profile_name(
+    client, mock_open_directory, mock_profile_manager, tmp_path
+):
+    """账号名里的路径分隔符与非法字符必须被清洗，不能写到导出目录之外。"""
+    mock_profile_manager.get_active_profile_name.return_value = "../../evil:name?"
+
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": PNG_BASE64, "open_folder": False},
+    )
+
+    data = response.json()
+    assert data["success"] is True
+    assert "/" not in data["file_name"]
+    assert "\\" not in data["file_name"]
+    assert ":" not in data["file_name"]
+    assert (tmp_path / "exports" / data["file_name"]).exists()
+
+
+def test_export_skips_open_folder_when_disabled(client, mock_open_directory):
+    """open_folder=false 时不应触发打开文件夹。"""
+    client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": PNG_BASE64, "open_folder": False},
+    )
+
+    mock_open_directory.assert_not_called()
+
+
+def test_export_opens_folder_when_enabled(client, mock_open_directory):
+    """open_folder=true 时应触发打开文件夹。"""
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": PNG_BASE64, "open_folder": True},
+    )
+
+    assert response.json()["success"] is True
+    mock_open_directory.assert_called_once()
+
+
+def test_export_survives_open_folder_failure(client, mock_open_directory, tmp_path):
+    """打开文件夹失败不能把已经落盘成功的导出判为失败。"""
+    mock_open_directory.side_effect = OSError("explorer 挂了")
+
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": PNG_BASE64, "open_folder": True},
+    )
+
+    data = response.json()
+    assert data["success"] is True
+    assert "打开文件夹失败" in data["message"]
+    assert (tmp_path / "exports" / data["file_name"]).exists()

--- a/tests/integration/test_matrix_export_api.py
+++ b/tests/integration/test_matrix_export_api.py
@@ -14,6 +14,9 @@ PNG_BASE64 = (
     "60e6kgAAAABJRU5ErkJggg=="
 )
 
+# 1x1 无损 WebP。前端主路径产出的就是 WebP，PNG 只是不支持时的回退。
+WEBP_BASE64 = "UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA="
+
 
 @pytest.fixture
 def mock_profile_manager():
@@ -42,8 +45,26 @@ def mock_open_directory():
         yield mock
 
 
+def test_export_saves_webp(client, mock_open_directory, tmp_path):
+    """WebP 是前端主路径，应落盘为 .webp 而不是被当成 PNG。"""
+    response = client.post(
+        "/api/export/treasure_matrix",
+        json={"image_base64": WEBP_BASE64, "open_folder": False},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["file_name"].startswith("default_")
+    assert data["file_name"].endswith(".webp")
+
+    saved = tmp_path / "exports" / data["file_name"]
+    assert saved.exists()
+    assert saved.read_bytes() == base64.b64decode(WEBP_BASE64)
+
+
 def test_export_saves_png(client, mock_open_directory, tmp_path):
-    """合法 PNG 应落盘到导出目录，并返回文件路径。"""
+    """PNG 是浏览器不支持 WebP 编码时的回退通道，同样要能落盘。"""
     response = client.post(
         "/api/export/treasure_matrix",
         json={"image_base64": PNG_BASE64, "open_folder": False},
@@ -60,12 +81,12 @@ def test_export_saves_png(client, mock_open_directory, tmp_path):
     assert saved.read_bytes() == base64.b64decode(PNG_BASE64)
 
 
-def test_export_rejects_non_png(client, mock_open_directory):
-    """非 PNG 内容必须被拒绝，这个接口不做通用文件落盘。"""
+def test_export_rejects_unsupported_format(client, mock_open_directory):
+    """既不是 WebP 也不是 PNG 的内容必须被拒绝，这个接口不做通用文件落盘。"""
     response = client.post(
         "/api/export/treasure_matrix",
         json={
-            "image_base64": base64.b64encode(b"not a png at all").decode(),
+            "image_base64": base64.b64encode(b"not an image at all").decode(),
             "open_folder": False,
         },
     )
@@ -73,6 +94,7 @@ def test_export_rejects_non_png(client, mock_open_directory):
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is False
+    assert "WebP" in data["message"]
     assert "PNG" in data["message"]
     assert data["file_path"] is None
 


### PR DESCRIPTION
新增宝藏基质（武器）导出为图片功能，支持将筛选后的武器/基质数据导出为工业档案风格的长图。

### 功能概述
- 在武器总览页新增「导出为图片」入口按钮
- 导出弹窗支持按星级筛选、包含满级/未获得条目、仅导出参与计算的条目等选项
- 未获得的条目按 0/6·0/6·0/3 置灰展示
- 卡片底部显示三词条名称（如"攻击·终结技充能效率·巧技"）
- 支持复制到剪贴板和保存为文件

### 导出格式:
- 主路径使用 WebP（lossy quality=1），相比 PNG 大幅缩小体积
- 剪贴板写入时现场转换为 PNG（Chromium clipboard API 限制）
- 后端按魔数判断格式，WebP 存 .webp，PNG 回退存 .png

### 视觉风格:
- 采用工业档案风格，移除 Vuetify 主题依赖
- 页头包含品牌块、档案抬头、一图流二维码、数据库筛选栏
- 页脚包含档案编号、仓库地址、署名、警示斜纹分隔
- 背景层增加噪点贴图与工业网格

### 卡片设计:
- 直角切角替代圆角、内衬线金属框、黄色锚点体系
- 满级标记改为黄色双线框 + 右上切角
- 方格能量条改为直角实心块
- 未获得卡片使用压向背景的独立色板

<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/a89474f8-8703-4bec-9e49-b9adfb02de49" />

---

<img width="330" height="470" alt="default_20260818-004402" src="https://github.com/user-attachments/assets/4d222270-e991-4f07-9316-f13ab98e8d33" />

<img width="330" height="470" alt="default_20260818-010402" src="https://github.com/user-attachments/assets/e6eab80e-0184-44a6-99a2-2fd3d4b7ee7a" />

