### PR TITLE
feat(scanner): 新增冗余清理模式（实验性），扫描结束后自动淘汰同武器冗余基质

### DIFF
--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -708,6 +708,51 @@
               </v-radio-group>
             </v-col>
           </v-row>
+
+          <v-divider class="my-4" />
+
+          <h2>对于<span class="text-warning">冗余基质</span>，我们</h2>
+          <p class="text-body-2 text-medium-emphasis mb-2">
+            扫描结束时会对比本轮记录，将同一武器名下多余的已锁定宝藏基质判定为冗余基质，
+            并按下方规则操作。需先开启「冗余清理（实验性）」，否则不产生任何记录与操作。
+          </p>
+          <v-row align="center">
+            <v-col cols="12" md="6">
+              <v-radio-group v-model="redundantAction" color="primary" density="comfortable">
+                <v-radio label="不去动它" value="keep" />
+                <v-radio label="把它锁上" value="lock" />
+                <v-radio label="把它标记为弃用" value="deprecate" />
+                <v-radio label="如果锁着，则解锁" value="unlock" />
+                <v-radio label="如果已标记为弃用，则取消弃用" value="undeprecate" />
+                <v-radio label="解锁且取消弃用" value="unlock_and_undeprecate" />
+                <v-radio label="如果没有上锁，则弃用" value="deprecate_if_not_locked" />
+                <v-radio label="如果没有弃用，则上锁" value="lock_if_not_deprecated" />
+                <v-radio label="如果缺少词条，则弃用" value="deprecate_if_missing_stats" />
+              </v-radio-group>
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-switch
+                v-model="redundantCleanupEnabled"
+                color="primary"
+                density="comfortable"
+                hide-details
+                label="冗余清理（实验性）"
+              />
+              <v-alert border="start" class="mt-2 mb-4" type="info" variant="tonal">
+                开启后，扫描结束后会回到背包顶部逐页回访并清理冗余基质；关闭时扫描行为与之前完全一致。
+              </v-alert>
+              <v-radio-group
+                v-model="redundantCleanupTrigger"
+                color="primary"
+                density="comfortable"
+                :disabled="!redundantCleanupEnabled"
+                label="清理时机"
+              >
+                <v-radio label="仅在扫描到尾页时启用" value="scan_complete" />
+                <v-radio label="所有情况下均启用（含手动停止扫描）" value="always" />
+              </v-radio-group>
+            </v-col>
+          </v-row>
         </v-expansion-panel-text>
       </v-expansion-panel>
 
@@ -986,6 +1031,9 @@ const sameTypeGroupMode = ref<'by_stat' | 'by_weapon'>('by_stat')
 const sameTypeKeepBest = ref(true)
 const sameTypeKeepBestMode = ref<'sequential' | 'sum' | 'weighted_sum'>('sequential')
 const sameTypeNonDowngradeFilter = ref(true)
+const redundantCleanupEnabled = ref(false)
+const redundantCleanupTrigger = ref<'scan_complete' | 'always'>('scan_complete')
+const redundantAction = ref('deprecate')
 const updateFlow = ref('github')
 const updateGithubMirror = ref('github')
 const updateProxyEnabled = ref(false)
@@ -1190,7 +1238,7 @@ function isTypePartiallySelected(groupId: string): boolean {
 const config = computed(() => {
   const proxyUrl = updateProxyEnabled.value ? `http://127.0.0.1:${updateProxyPort.value}` : ''
   return {
-    version: 8,
+    version: 9,
     trash_weapon_ids: notSelectedWeaponIds.value,
     treasure_essence_stats: treasureEssenceStats.value,
     treasure_essence_match_mode: 'all' as const,
@@ -1230,6 +1278,9 @@ const config = computed(() => {
     same_type_keep_best: sameTypeKeepBest.value,
     same_type_keep_best_mode: sameTypeKeepBestMode.value,
     same_type_non_downgrade_filter: sameTypeNonDowngradeFilter.value,
+    redundant_cleanup_enabled: redundantCleanupEnabled.value,
+    redundant_cleanup_trigger: redundantCleanupTrigger.value,
+    redundant_action: redundantAction.value,
     update_mirror: updateGithubMirror.value,
     update_flow: updateFlow.value,
     update_github_mirror: updateGithubMirror.value,
@@ -1277,6 +1328,9 @@ async function getConfig() {
     same_type_keep_best,
     same_type_keep_best_mode,
     same_type_non_downgrade_filter,
+    redundant_cleanup_enabled,
+    redundant_cleanup_trigger,
+    redundant_action,
     update_flow,
     update_github_mirror,
     update_mirror,
@@ -1319,6 +1373,9 @@ async function getConfig() {
   sameTypeKeepBest.value = same_type_keep_best !== false
   sameTypeKeepBestMode.value = same_type_keep_best_mode || 'sequential'
   sameTypeNonDowngradeFilter.value = same_type_non_downgrade_filter !== false
+  redundantCleanupEnabled.value = redundant_cleanup_enabled === true
+  redundantCleanupTrigger.value = redundant_cleanup_trigger || 'scan_complete'
+  redundantAction.value = redundant_action || 'deprecate'
   updateFlow.value = normalizeUpdateFlow(update_flow, update_mirror)
   updateGithubMirror.value = update_github_mirror || getLegacyGithubMirror(update_mirror)
   updateMirrorChyanResId.value = update_mirrorchyan_res_id || ''

--- a/frontend/src/pages/settings.vue
+++ b/frontend/src/pages/settings.vue
@@ -713,8 +713,10 @@
 
           <h2>对于<span class="text-warning">冗余基质</span>，我们</h2>
           <p class="text-body-2 text-medium-emphasis mb-2">
-            扫描结束时会对比本轮记录，将同一武器名下多余的已锁定宝藏基质判定为冗余基质，
-            并按下方规则操作。需先开启「冗余清理（实验性）」，否则不产生任何记录与操作。
+            <strong>冗余基质：</strong
+            >本次扫描中，同一把武器在后面扫到了相同/更好等级，先扫到的那一枚为「冗余基质」。<br />
+            <strong>启用条件：</strong
+            >右侧开启「冗余清理（实验性）」，且分组为「按武器划分」并「开启数量上限」，否则不产生任何记录与操作。<br />
           </p>
           <v-row align="center">
             <v-col cols="12" md="6">
@@ -739,7 +741,7 @@
                 label="冗余清理（实验性）"
               />
               <v-alert border="start" class="mt-2 mb-4" type="info" variant="tonal">
-                开启后，扫描结束后会回到背包顶部逐页回访并清理冗余基质；关闭时扫描行为与之前完全一致。
+                启用后，将在扫描结束后回到顶部，逐页清理本次扫描中的冗余基质。
               </v-alert>
               <v-radio-group
                 v-model="redundantCleanupTrigger"

--- a/src/endfield_essence_recognizer/core/layout/base.py
+++ b/src/endfield_essence_recognizer/core/layout/base.py
@@ -152,3 +152,8 @@ class ResolutionProfile(Protocol):
     def SCROLLBAR_CHECK_POS(self) -> Point:
         """滚动条检测位置。"""
         ...
+
+    @property
+    def SCROLLBAR_TOP_CHECK_POS(self) -> Point:
+        """滚动条顶部检测位置（冗余清理回页首时判断是否已滚动到位）。"""
+        ...

--- a/src/endfield_essence_recognizer/core/layout/dynamic.py
+++ b/src/endfield_essence_recognizer/core/layout/dynamic.py
@@ -277,3 +277,22 @@ class DynamicResolutionProfile(ResolutionProfile):
         x = self._width - right_margin
         y = self._height - bottom_margin
         return Point(x, y)
+
+    @property
+    def SCROLLBAR_TOP_CHECK_POS(self) -> Point:
+        """滚动条顶部检测位置，用于判断是否回到第一页。
+
+        与行末检测（SCROLLBAR_CHECK_POS）同一套缩放律，取对称的顶部边距：
+        右边距 ≈ 高度 × 0.432，顶部边距 ≈ 高度 × 0.12。
+        """
+        base_height = 1080
+        base_right_margin = 467
+        base_top_margin = 130
+
+        scale = self._height / base_height
+        right_margin = round(base_right_margin * scale)
+        top_margin = round(base_top_margin * scale)
+
+        x = self._width - right_margin
+        y = top_margin
+        return Point(x, y)

--- a/src/endfield_essence_recognizer/core/layout/res_1080p.py
+++ b/src/endfield_essence_recognizer/core/layout/res_1080p.py
@@ -98,3 +98,8 @@ class Resolution1080p(ResolutionProfile):
     def SCROLLBAR_CHECK_POS(self) -> Point:
         """滚动条检测位置，用于判断是否到达底部"""
         return Point(1453, 950)
+
+    @property
+    def SCROLLBAR_TOP_CHECK_POS(self) -> Point:
+        """滚动条顶部检测位置，用于判断是否回到第一页"""
+        return Point(1453, 130)

--- a/src/endfield_essence_recognizer/core/scanner/action_logic.py
+++ b/src/endfield_essence_recognizer/core/scanner/action_logic.py
@@ -49,6 +49,7 @@ def decide_actions(
     data: EssenceData,
     evaluation: EvaluationResult,
     setting: UserSetting,
+    target_action: Action | None = None,
 ) -> list[ScannerAction]:
     """
     Decides what physical actions to perform based on the current state vs desired quality.
@@ -66,6 +67,8 @@ def decide_actions(
         data: Current state of the essence (locked?, observed?).
         evaluation: The judged quality (Treasure/Trash) from evaluate_essence.
         setting: User preferences for actions (e.g. treasure_action=LOCK).
+        target_action: 覆盖目标操作（冗余清理传入 setting.redundant_action）；
+            None 时按 quality 取 treasure_action / trash_action。
 
     Returns:
         An ordered list of actions to apply to the game client sequentially.
@@ -75,14 +78,16 @@ def decide_actions(
 
     actions: list[ScannerAction] = []
 
+    if target_action is None:
+        target_action = (
+            setting.treasure_action
+            if evaluation.quality == EssenceQuality.TREASURE
+            else setting.trash_action
+        )
+
     # --- Lock Logic ---
     should_lock = False
     should_unlock = False
-
-    if evaluation.quality == EssenceQuality.TREASURE:
-        target_action = setting.treasure_action
-    else:  # TRASH
-        target_action = setting.trash_action
 
     if target_action == Action.LOCK:
         should_lock = True

--- a/src/endfield_essence_recognizer/core/scanner/claimer.py
+++ b/src/endfield_essence_recognizer/core/scanner/claimer.py
@@ -22,6 +22,7 @@ from endfield_essence_recognizer.core.scanner.evaluate import (
     _order_candidate_ids,
 )
 from endfield_essence_recognizer.core.scanner.models import (
+    ClaimKind,
     ClaimResult,
     ClassificationResult,
     EssenceData,
@@ -410,7 +411,11 @@ class ClaimContext:
                     f"[相同等级] 武器 {self._display(wid)} 已记录等级 {current_levels}，"
                     f"消耗存量跳过名额（剩余 {skip - 1}），不重复认领"
                 )
-                return ClaimResult(updated_levels={wid: current_levels})
+                return ClaimResult(
+                    updated_levels={wid: current_levels},
+                    claim_kind=ClaimKind.SKIP_EXISTING,
+                    owner_key=wid,
+                )
 
         # ② 组内空槽：优先序中第一把无记录的武器认领落盘（孪生武器不饿死）
         for wid in weapon_ids:
@@ -424,6 +429,8 @@ class ClaimContext:
                 return ClaimResult(
                     accepted_weapon_id=wid,
                     updated_levels={wid: current_levels},
+                    claim_kind=ClaimKind.NEW_SLOT,
+                    owner_key=wid,
                 )
 
         # ③ 无空槽：判定宝藏、不落盘（占用该武器限额名额）
@@ -438,6 +445,8 @@ class ClaimContext:
                 return ClaimResult(
                     accepted_weapon_id=wid,
                     updated_levels={wid: self.best_levels[wid]},
+                    claim_kind=ClaimKind.COUNT_ONLY,
+                    owner_key=wid,
                 )
 
         # 全部满额：与限额语义一致，标记为养成材料
@@ -501,6 +510,11 @@ class ClaimContext:
                 updated_levels={weapon_id: current_levels},
                 cascade_updated=cascade,
                 group_stat_key=group_stat_key,
+                claim_kind=(
+                    ClaimKind.UPGRADE if old_best is not None else ClaimKind.NEW_SLOT
+                ),
+                owner_key=weapon_id,
+                released_levels=old_best,
             )
 
         # 无人可认领
@@ -523,6 +537,8 @@ class ClaimContext:
             accepted_weapon_id=target,
             updated_levels={target: self.best_levels.get(target) or current_levels},
             group_stat_key=group_stat_key,
+            claim_kind=ClaimKind.COUNT_ONLY,
+            owner_key=target,
         )
 
     def _claim_limit_on(
@@ -563,10 +579,15 @@ class ClaimContext:
                         accepted_weapon_id=weapon_id,
                         updated_levels={weapon_id: current_levels},
                         cascade_updated=cascade,
+                        claim_kind=ClaimKind.UPGRADE,
+                        owner_key=weapon_id,
+                        released_levels=old_best,
                     )
                 return ClaimResult(
                     accepted_weapon_id=weapon_id,
                     updated_levels={weapon_id: current_levels},
+                    claim_kind=ClaimKind.SKIP_EXISTING,
+                    owner_key=weapon_id,
                 )
 
             # 数量上限认领
@@ -577,6 +598,8 @@ class ClaimContext:
                 return ClaimResult(
                     accepted_weapon_id=weapon_id,
                     updated_levels={weapon_id: current_levels},
+                    claim_kind=ClaimKind.NEW_SLOT,
+                    owner_key=weapon_id,
                 )
 
             # 未被认领：判断拒绝原因
@@ -719,13 +742,19 @@ class ClaimContext:
             if keep_best and self._try_keep_best(
                 stat_key, current_levels, mode, stat_types
             ):
-                return ClaimResult()
+                return ClaimResult(
+                    claim_kind=ClaimKind.UPGRADE,
+                    owner_key=stat_key,
+                )
 
             # 数量上限：未达上限则新增并计数
             if self._try_claim_slot(
                 stat_key, current_levels, limit, keep_best, mode, stat_types
             ):
-                return ClaimResult()
+                return ClaimResult(
+                    claim_kind=ClaimKind.NEW_SLOT,
+                    owner_key=stat_key,
+                )
 
             # 未被认领：未达上限说明是被留大弃小拦下的更差基质
             count = self.treasure_counts.get(stat_key, 0)
@@ -769,7 +798,11 @@ class ClaimContext:
                     skip = self.equal_skips.get(weapon_id, 0)
                     if skip > 0:
                         self.equal_skips[weapon_id] = skip - 1
-                        return ClaimResult(accepted_weapon_id=weapon_id)
+                        return ClaimResult(
+                            accepted_weapon_id=weapon_id,
+                            claim_kind=ClaimKind.SKIP_EXISTING,
+                            owner_key=stat_key,
+                        )
                 if (
                     best is not None
                     and _level_cmp(current_levels, best, mode, stat_types) > 0
@@ -778,6 +811,9 @@ class ClaimContext:
                     return ClaimResult(
                         accepted_weapon_id=weapon_id,
                         updated_levels={weapon_id: current_levels},
+                        claim_kind=ClaimKind.UPGRADE,
+                        owner_key=stat_key,
+                        released_levels=best,
                     )
 
             if count < limit:
@@ -801,6 +837,8 @@ class ClaimContext:
                 return ClaimResult(
                     accepted_weapon_id=weapon_id,
                     updated_levels={weapon_id: current_levels},
+                    claim_kind=ClaimKind.NEW_SLOT,
+                    owner_key=stat_key,
                 )
 
         # 虚拟武器
@@ -821,7 +859,10 @@ class ClaimContext:
                 break
             self.treasure_counts[stat_key] = count + 1
             self.best_levels[virtual_key] = current_levels
-            return ClaimResult()
+            return ClaimResult(
+                claim_kind=ClaimKind.VIRTUAL_SLOT,
+                owner_key=stat_key,
+            )
 
         return ClaimResult(
             reject_reason=RejectReason.LIMIT,

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -325,6 +325,9 @@ class ScannerEngine:
         self._cleanup_records: list[_CleanupRecord] = []
         self._cleanup_designated: dict[str, list[_CleanupRecord]] = {}
         self._cleanup_page_index = 1
+        self._cleanup_flipped_pages = False
+        self._cleanup_corrected_pages: set[int] = set()
+        self._cleanup_max_page = 1
 
         from endfield_essence_recognizer.utils.log import str_properties_and_attrs
 
@@ -388,6 +391,9 @@ class ScannerEngine:
         self._cleanup_records = []
         self._cleanup_designated = {}
         self._cleanup_page_index = 1
+        self._cleanup_flipped_pages = False
+        self._cleanup_corrected_pages = set()
+        self._cleanup_max_page = 1
         self._cleanup_active = (
             user_setting.redundant_cleanup_enabled
             and user_setting.same_type_treasure_limit_enabled
@@ -475,6 +481,19 @@ class ScannerEngine:
                 return records.pop(index)
         return None
 
+    def _cleanup_records_snapshot(self) -> int:
+        """返回当前账本记录数，供翻页过冲检测首行 pass 的回滚使用。"""
+        return len(self._cleanup_records)
+
+    def _cleanup_records_rollback(self, snapshot: int) -> None:
+        """回滚自快照以来新增的账本记录。
+
+        翻页过冲检测时，首行扫到的是上一页的重复基质，其位置记录会随
+        3/4 行校正失效；回滚后这些基质仍由上一页的正确位置记录覆盖。
+        designated 中残留的引用无副作用：判定只遍历 _cleanup_records。
+        """
+        del self._cleanup_records[snapshot:]
+
     def _maybe_run_cleanup(
         self,
         scan_completed_naturally: bool,
@@ -515,8 +534,11 @@ class ScannerEngine:
             return
 
         logger.info(f"冗余清理：发现 {len(redundant)} 枚冗余基质，开始清理。")
+        self._cleanup_max_page = max((record.page for record in redundant), default=1)
         if not self._reset_to_first_page(stop_event):
-            logger.info("冗余清理被中断。")
+            # 放弃原因已由 _reset_to_first_page 记录；停止事件则补一条中断日志
+            if stop_event.is_set():
+                logger.info("冗余清理被中断。")
             return
         current_page = 1
 
@@ -1134,6 +1156,8 @@ class DraggableScannerEngine(ScannerEngine):
             page_count += 1
             logger.info(f"开始扫描第 {page_count} 页基质...")
             self._cleanup_page_index = page_count
+            if page_count > 1:
+                self._cleanup_flipped_pages = True
 
             if is_last_page and page_count > 1:
                 # 最后一页：根据渐进滚动距离计算需要跳过的行数
@@ -1155,11 +1179,17 @@ class DraggableScannerEngine(ScannerEngine):
                     start_row_index=start_row,
                 )
             elif page_count > 1:
-                # 非首页：先扫描第一行（含操作），检测是否全部重复
+                # 非首页：先扫描第一行（含操作），检测是否全部重复。
+                # 冗余清理：过冲检测首行先不入账——若确认过冲并执行 3/4 行
+                # 校正，该 pass 的位置记录作废，回滚账本；该页校正后的网格
+                # 偏移记入 _cleanup_corrected_pages，清理导航时重放校正。
+                cleanup_snapshot = self._cleanup_records_snapshot()
                 all_dup = self._scan_single_row(
                     0, stop_event, user_setting, icon_x_list, icon_y_list
                 )
                 if all_dup and user_setting.fix_page_flip_overscroll:
+                    self._cleanup_records_rollback(cleanup_snapshot)
+                    self._cleanup_corrected_pages.add(page_count)
                     row_height = (
                         icon_y_list[1] - icon_y_list[0] if len(icon_y_list) > 1 else 0
                     )
@@ -1491,9 +1521,14 @@ class DraggableScannerEngine(ScannerEngine):
         """冗余清理：滚动条顶端 16px 上拖，配合顶部亮点检测回到第一页。
 
         拖动距离恒定 16px（不随分辨率缩放，过小可能无法被游戏识别）；
-        起点随分辨率缩放。检测不到亮点时按已在第一页继续（重试耗尽后由
-        回访指纹校验兜底，单页背包可能无滚动条滑块）。
+        起点随分辨率缩放。本轮从未翻页时无需确认（物理上就在第一页）；
+        翻过页但 3 次尝试仍未确认回到顶部时放弃清理——不能按假定页码
+        继续，指纹校验无法区分相同内容的基质。
         """
+        if not self._cleanup_flipped_pages:
+            logger.debug("冗余清理：本轮未翻页，直接按第一页处理。")
+            return True
+
         top = self._profile.SCROLLBAR_TOP_CHECK_POS
         start = Point(top.x, top.y + _SCROLL_TOP_DRAG_PX)
 
@@ -1517,8 +1552,8 @@ class DraggableScannerEngine(ScannerEngine):
                 logger.info(f"冗余清理：已回到第一页（第 {attempt} 次尝试）。")
                 return True
 
-        logger.warning("冗余清理：未检测到滚动条顶部亮点，按已在第一页继续。")
-        return True
+        logger.warning("冗余清理：3 次尝试未确认回到第一页，放弃本次清理。")
+        return False
 
     def _advance_to_page(
         self,
@@ -1530,8 +1565,10 @@ class DraggableScannerEngine(ScannerEngine):
         """冗余清理：从当前页向前翻页到目标页，完全复用扫描时的翻页机件。
 
         与扫描翻页保持同一路径（渐进拖动 + 行末检测 + 暗带对齐），保证
-        回访页的网格行偏移与扫描时一致；提前检测到列表底部时停止翻页
-        （该位置即最后扫描页，目标页记录必然在其上）。
+        回访页的网格行偏移与扫描时一致；到达扫描期执行过过冲校正的页时
+        重放同参数的 3/4 行校正。提前检测到列表底部时，仅当目标页就是
+        最后扫描页（_cleanup_max_page）才视为到达，否则翻页序列已发散，
+        放弃本次清理。
         """
         drag_start = self._profile.DRAG_START_POS
         drag_end = self._profile.DRAG_END_POS
@@ -1561,13 +1598,31 @@ class DraggableScannerEngine(ScannerEngine):
                 row_height=row_height,
             )
             if is_last_page:
-                # 已到底部（最后扫描页）：与扫描时的翻页状态一致，停止翻页
+                # 提前到底：物理位置即最后扫描页，仅当目标页就是它时视为到达
+                if target_page != self._cleanup_max_page:
+                    logger.warning(
+                        f"冗余清理：翻页提前到达列表底部，但目标为第 {target_page} 页"
+                        f"（最后扫描页为第 {self._cleanup_max_page} 页），放弃本次清理。"
+                    )
+                    return False
                 break
             if user_setting.fix_grid_row_offset_after_page_flip:
                 self._align_grid_rows_after_drag(drag_start, icon_x_list, icon_y_list)
             if self._check_scrollbar_at_bottom(scrollbar_pos):
-                logger.debug("冗余清理：翻页后检测到滚动条到底。")
+                # 同提前到底处理：翻页后检测到底部
+                if target_page != self._cleanup_max_page:
+                    logger.warning(
+                        f"冗余清理：翻页后到达列表底部，但目标为第 {target_page} 页"
+                        f"（最后扫描页为第 {self._cleanup_max_page} 页），放弃本次清理。"
+                    )
+                    return False
                 break
+
+        # 重放扫描期对该页执行的过冲校正（3/4 行），保证与记录时的网格布局一致
+        if target_page in self._cleanup_corrected_pages:
+            if row_height > 0:
+                self._correct_overscroll(drag_start, round(row_height * 3 / 4))
+                logger.debug(f"冗余清理：回放第 {target_page} 页的过冲校正。")
         return True
 
     def _progressive_drag(

--- a/src/endfield_essence_recognizer/core/scanner/engine.py
+++ b/src/endfield_essence_recognizer/core/scanner/engine.py
@@ -1,6 +1,7 @@
 import itertools
 import math
 import threading
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -27,17 +28,47 @@ from endfield_essence_recognizer.core.scanner.classifier import classify_essence
 from endfield_essence_recognizer.core.scanner.context import (
     ScannerContext,
 )
-from endfield_essence_recognizer.core.scanner.evaluate import _group_stat_key
+from endfield_essence_recognizer.core.scanner.evaluate import (
+    _group_stat_key,
+    _normalize_by_stat_type,
+)
 from endfield_essence_recognizer.core.scanner.log_builder import build_evaluation_result
 from endfield_essence_recognizer.core.scanner.models import (
+    ClaimKind,
     EssenceData,
     EssenceQuality,
+    EvaluationResult,
 )
 from endfield_essence_recognizer.core.window.adapter import InMemoryImageSource
 from endfield_essence_recognizer.game_data.models.v2 import StatType, WeaponId
-from endfield_essence_recognizer.schemas.user_setting import UserSetting
+from endfield_essence_recognizer.schemas.user_setting import (
+    CleanupTriggerMode,
+    SameTypeGroupMode,
+    UserSetting,
+)
 from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
 from endfield_essence_recognizer.utils.log import logger
+
+#: 冗余清理回页首手势的拖动距离（像素）。不随分辨率缩放：
+#: 过小的拖动可能无法被游戏识别。
+_SCROLL_TOP_DRAG_PX = 16
+
+
+@dataclass
+class _CleanupRecord:
+    """冗余清理（实验性）：单枚宝藏基质的物理记录。
+
+    仅记录本轮扫描判定为宝藏的基质；位置使用逻辑索引（页、行、列），
+    回访时结合本次会话的 ResolutionProfile 反查点击坐标。
+    """
+
+    page: int
+    row: int
+    col: int
+    levels: tuple[int, int, int]
+    fingerprint: str
+    owner: str
+    """最终归属武器 ID（级联可转移）。"""
 
 
 def check_scene(
@@ -289,6 +320,12 @@ class ScannerEngine:
         # 跟踪每个属性组合已跳过的同等级基质次数
         self._skip_exact_level_counts: dict[tuple, int] = {}
 
+        # 冗余清理（实验性）运行时状态
+        self._cleanup_active = False
+        self._cleanup_records: list[_CleanupRecord] = []
+        self._cleanup_designated: dict[str, list[_CleanupRecord]] = {}
+        self._cleanup_page_index = 1
+
         from endfield_essence_recognizer.utils.log import str_properties_and_attrs
 
         logger.opt(lazy=True).debug(
@@ -343,6 +380,255 @@ class ScannerEngine:
             for weapon_id in self.ctx.static_game_data.find_weapons_by_stats(*stat_key):
                 result[weapon_id] = count
         return result
+
+    # ── 冗余清理（实验性）──
+
+    def _init_cleanup_state(self, user_setting: UserSetting) -> None:
+        """按用户设置初始化本轮扫描的冗余清理状态（无副作用）。"""
+        self._cleanup_records = []
+        self._cleanup_designated = {}
+        self._cleanup_page_index = 1
+        self._cleanup_active = (
+            user_setting.redundant_cleanup_enabled
+            and user_setting.same_type_treasure_limit_enabled
+            and user_setting.same_type_group_mode == SameTypeGroupMode.BY_WEAPON
+        )
+        if user_setting.redundant_cleanup_enabled and not self._cleanup_active:
+            logger.warning(
+                "冗余清理已开启，但当前配置暂不支持（需启用数量上限且按武器划分），本次跳过。"
+            )
+
+    def _get_essence_hash(self, data: EssenceData) -> str:
+        """
+        生成基质指纹用于去重检测。
+
+        使用稀有度、属性类型和属性等级作为指纹。
+        """
+        stats_str = "_".join(str(s) if s is not None else "?" for s in data.stats)
+        levels_str = "_".join(str(lv) if lv is not None else "?" for lv in data.levels)
+        return f"{data.rarity.value}_{stats_str}_{levels_str}"
+
+    def _record_cleanup_claim(
+        self,
+        claim_result,
+        data: EssenceData,
+        page: int,
+        row: int,
+        col: int,
+    ) -> None:
+        """按认领路径把一枚宝藏基质记入冗余清理的名额账本。
+
+        账本语义与 ClaimContext 的名额状态机一致：
+        - 新增名额 / 仅计数 / 存量跳过 → 追加为当前持有者；
+        - 升级替换 → 释放旧最优持有者，级联则把释放记录转移归属。
+        """
+        kind = claim_result.claim_kind
+        if kind not in (
+            ClaimKind.NEW_SLOT,
+            ClaimKind.UPGRADE,
+            ClaimKind.SKIP_EXISTING,
+            ClaimKind.COUNT_ONLY,
+        ):
+            return
+        owner = claim_result.owner_key
+        if not isinstance(owner, str) or not owner:
+            return
+
+        # 记录语义顺序（属性、副属性、技能）的等级，与 claimer 的
+        # released_levels / best_levels 对齐；识别位置顺序不保证等于语义顺序
+        _stat_key, _ordered_types, current_levels = _normalize_by_stat_type(
+            data.stats, data.stat_types, data.levels
+        )
+        record = _CleanupRecord(
+            page=page,
+            row=row,
+            col=col,
+            levels=current_levels,
+            fingerprint=self._get_essence_hash(data),
+            owner=owner,
+        )
+        self._cleanup_records.append(record)
+        self._cleanup_designated.setdefault(owner, []).append(record)
+
+        if kind == ClaimKind.UPGRADE:
+            released = self._release_cleanup_holder(owner, claim_result.released_levels)
+            if released is not None and claim_result.cascade_updated:
+                # 级联：释放的旧等级转移给目标武器（_cascade_freed 每次至多一个目标）
+                for target_weapon in claim_result.cascade_updated:
+                    released.owner = target_weapon
+                    self._cleanup_designated.setdefault(target_weapon, []).append(
+                        released
+                    )
+                    break
+
+    def _release_cleanup_holder(
+        self, owner: str, released_levels: tuple[int, int, int] | None
+    ) -> _CleanupRecord | None:
+        """释放 owner 当前最优持有者（最近追加的同等级记录）；找不到则返回 None。"""
+        if released_levels is None:
+            return None
+        records = self._cleanup_designated.get(owner)
+        if not records:
+            return None
+        for index in range(len(records) - 1, -1, -1):
+            if records[index].levels == released_levels:
+                return records.pop(index)
+        return None
+
+    def _maybe_run_cleanup(
+        self,
+        scan_completed_naturally: bool,
+        stop_event: threading.Event,
+        user_setting: UserSetting,
+    ) -> None:
+        """按触发模式决定是否执行冗余清理。
+
+        手动停止触发的清理会先清除停止事件（清理过程中用户可再次按停止取消）。
+        """
+        if not self._cleanup_active:
+            return
+        if not scan_completed_naturally and (
+            user_setting.redundant_cleanup_trigger != CleanupTriggerMode.ALWAYS
+        ):
+            return
+        if not scan_completed_naturally:
+            stop_event.clear()
+        try:
+            self._run_cleanup(stop_event, user_setting)
+        except Exception:
+            logger.exception("冗余清理执行失败，已跳过。")
+
+    def _run_cleanup(
+        self, stop_event: threading.Event, user_setting: UserSetting
+    ) -> None:
+        """执行冗余清理：判定冗余 → 回第一页 → 逐页回访 → 按规则操作。"""
+        kept_ids = {
+            id(record)
+            for records in self._cleanup_designated.values()
+            for record in records
+        }
+        redundant = [
+            record for record in self._cleanup_records if id(record) not in kept_ids
+        ]
+        if not redundant:
+            logger.info("冗余清理：本轮扫描没有冗余基质。")
+            return
+
+        logger.info(f"冗余清理：发现 {len(redundant)} 枚冗余基质，开始清理。")
+        if not self._reset_to_first_page(stop_event):
+            logger.info("冗余清理被中断。")
+            return
+        current_page = 1
+
+        by_page: dict[int, list[_CleanupRecord]] = {}
+        for record in redundant:
+            by_page.setdefault(record.page, []).append(record)
+
+        for page in sorted(by_page):
+            if not self._window_actions.target_is_active:
+                logger.warning("终末地窗口不在前台，中止冗余清理。")
+                return
+            if stop_event.is_set():
+                logger.info("冗余清理被中断。")
+                return
+            if not self._advance_to_page(current_page, page, stop_event, user_setting):
+                logger.warning("冗余清理：翻页失败，放弃本次清理。")
+                return
+            current_page = page
+            outcome = self._visit_cleanup_records(
+                by_page[page], stop_event, user_setting
+            )
+            if outcome == "page_mismatch":
+                logger.warning("冗余清理：整页指纹均不匹配，放弃本次清理。")
+                return
+            if outcome == "aborted":
+                return
+        logger.info("冗余清理：清理完成。")
+
+    def _visit_cleanup_records(
+        self,
+        page_records: list[_CleanupRecord],
+        stop_event: threading.Event,
+        user_setting: UserSetting,
+    ) -> str:
+        """回访一页内的冗余基质并按「对于冗余基质」规则操作。
+
+        Returns:
+            "done" 至少一枚指纹匹配 / "page_mismatch" 全部不匹配 /
+            "aborted" 窗口失焦或用户停止。
+        """
+        matched_any = False
+        for record in page_records:
+            if not self._window_actions.target_is_active:
+                logger.warning("终末地窗口不在前台，中止冗余清理。")
+                return "aborted"
+            if stop_event.is_set():
+                logger.info("冗余清理被中断。")
+                return "aborted"
+
+            position = f"第{record.page}页第{record.row + 1}行第{record.col + 1}列"
+            self._window_actions.click(
+                self._profile.essence_icon_x_list[record.col],
+                self._profile.essence_icon_y_list[record.row],
+            )
+            self._window_actions.wait(0.3)
+
+            data = recognize_essence(self._image_source, self.ctx, self._profile)
+            if (
+                data.abandon_label == AbandonStatusLabel.MAYBE_ABANDONED
+                or data.lock_label == LockStatusLabel.MAYBE_LOCKED
+            ):
+                logger.warning(f"[冗余清理] {position} 识别不确定，跳过。")
+                continue
+            if self._get_essence_hash(data) != record.fingerprint:
+                logger.warning(f"[冗余清理] {position} 指纹不匹配，跳过。")
+                continue
+
+            matched_any = True
+            levels_text = "/".join(str(level) for level in record.levels)
+            evaluation = EvaluationResult(
+                quality=EssenceQuality.TRASH,
+                log_message="",
+            )
+            actions = decide_actions(
+                data,
+                evaluation,
+                user_setting,
+                target_action=user_setting.redundant_action,
+            )
+            if not actions:
+                logger.info(
+                    f"[冗余清理] {position} 等级 {levels_text} 已符合目标状态，无需操作。"
+                )
+                continue
+
+            for action in actions:
+                if action.type == ActionType.CLICK_LOCK:
+                    pos = self._profile.LOCK_BUTTON_POS
+                    self._window_actions.click(pos.x, pos.y)
+                elif action.type == ActionType.CLICK_ABANDON:
+                    pos = self._profile.DEPRECATE_BUTTON_POS
+                    self._window_actions.click(pos.x, pos.y)
+                self._window_actions.wait(0.3)
+            logger.opt(colors=True).success(
+                f"[冗余清理] {position} 基质等级 <magenta>{levels_text}</> "
+                "已按「对于冗余基质」规则处理。"
+            )
+        return "done" if matched_any else "page_mismatch"
+
+    def _reset_to_first_page(self, stop_event: threading.Event) -> bool:
+        """回到第一页。基类无翻页：当前页即第一页。"""
+        return True
+
+    def _advance_to_page(
+        self,
+        current_page: int,
+        target_page: int,
+        stop_event: threading.Event,
+        user_setting: UserSetting,
+    ) -> bool:
+        """从当前页前进到目标页。基类无翻页：直接成功。"""
+        return True
 
     def _sort_weapons_by_priority(self, weapon_ids: set[str]) -> list[str]:
         """按优先级排序武器ID（高优先级在前）。
@@ -555,6 +841,9 @@ class ScannerEngine:
         self._total_essence_count = 0
         self._skip_exact_level_counts = {}
 
+        # 初始化冗余清理（实验性）状态
+        self._init_cleanup_state(user_setting)
+
         # 从 profile 初始化已有武器等级，用于同等级跳过判断
         self._init_weapon_levels_from_profile()
 
@@ -576,6 +865,9 @@ class ScannerEngine:
 
         icon_x_list = self._profile.essence_icon_x_list
         icon_y_list = self._profile.essence_icon_y_list
+
+        # 是否自然完成（未被打断）；冗余清理按此区分触发模式
+        scan_completed_naturally = False
 
         for (i, relative_y), (j, relative_x) in itertools.product(
             enumerate(icon_y_list), enumerate(icon_x_list)
@@ -646,6 +938,10 @@ class ScannerEngine:
             if evaluation.quality != EssenceQuality.SKIP:
                 self._total_essence_count += 1
 
+            # 冗余清理（实验性）：记录本轮判为宝藏的基质
+            if self._cleanup_active and evaluation.quality == EssenceQuality.TREASURE:
+                self._record_cleanup_claim(claim_result, data, page=1, row=i, col=j)
+
             # 同步认领结果到引擎
             for weapon_id, levels in claim_result.updated_levels.items():
                 self._weapon_essence_levels[weapon_id] = levels
@@ -693,6 +989,10 @@ class ScannerEngine:
         else:
             # 扫描完成
             logger.info("基质扫描完成")
+            scan_completed_naturally = True
+
+        # 冗余清理（实验性）：按触发模式执行
+        self._maybe_run_cleanup(scan_completed_naturally, stop_event, user_setting)
 
         # 输出武器基质数量统计
         logger.info(f"共扫描了 {self._total_essence_count} 个基质。")
@@ -775,6 +1075,9 @@ class DraggableScannerEngine(ScannerEngine):
         # 重置已扫描基质指纹集合（用于翻页去重检测）
         self._scanned_essence_hashes: set[str] = set()
 
+        # 初始化冗余清理（实验性）状态
+        self._init_cleanup_state(user_setting)
+
         # 从 profile 初始化已有武器等级，用于同等级跳过判断
         self._init_weapon_levels_from_profile()
 
@@ -816,6 +1119,9 @@ class DraggableScannerEngine(ScannerEngine):
         is_last_page = False
         max_pages = 100  # 最大页数限制，防止无限循环
 
+        # 是否自然完成（扫到最后一页）；冗余清理按此区分触发模式
+        scan_completed_naturally = False
+
         # 初始化渐进拖动相关变量
         progressive_drag_distance = 0
         max_drag_distance = (
@@ -827,6 +1133,7 @@ class DraggableScannerEngine(ScannerEngine):
         while not stop_event.is_set() and page_count < max_pages:
             page_count += 1
             logger.info(f"开始扫描第 {page_count} 页基质...")
+            self._cleanup_page_index = page_count
 
             if is_last_page and page_count > 1:
                 # 最后一页：根据渐进滚动距离计算需要跳过的行数
@@ -889,6 +1196,7 @@ class DraggableScannerEngine(ScannerEngine):
             # 如果已经扫描完最后一页，停止扫描
             if is_last_page:
                 logger.info("已扫描完最后一页，基质扫描完成。")
+                scan_completed_naturally = True
                 break
 
             # 检查停止事件
@@ -928,6 +1236,10 @@ class DraggableScannerEngine(ScannerEngine):
 
         if page_count >= max_pages:
             logger.info(f"已达到最大页数限制 ({max_pages})，扫描停止。")
+
+        # 冗余清理（实验性）：按触发模式执行
+        self._maybe_run_cleanup(scan_completed_naturally, stop_event, user_setting)
+
         logger.info("基质扫描完成。")
 
         # 输出武器基质数量统计
@@ -1051,6 +1363,19 @@ class DraggableScannerEngine(ScannerEngine):
                 if evaluation.quality != EssenceQuality.SKIP:
                     self._total_essence_count += 1
 
+                # 冗余清理（实验性）：记录本轮判为宝藏的基质
+                if (
+                    self._cleanup_active
+                    and evaluation.quality == EssenceQuality.TREASURE
+                ):
+                    self._record_cleanup_claim(
+                        claim_result,
+                        data,
+                        page=self._cleanup_page_index,
+                        row=i,
+                        col=j,
+                    )
+
                 # 同步认领结果到引擎
                 for weapon_id, levels in claim_result.updated_levels.items():
                     self._weapon_essence_levels[weapon_id] = levels
@@ -1130,6 +1455,120 @@ class DraggableScannerEngine(ScannerEngine):
         except Exception as e:
             logger.warning(f"滚动条检测失败: {e}")
             return False
+
+    def _check_scrollbar_at_top(self) -> bool:
+        """检测滚动条是否已回到顶部（冗余清理回页首用）。
+
+        与 _check_scrollbar_at_bottom 对称：检测 SCROLLBAR_TOP_CHECK_POS
+        附近是否有亮点（滑块顶端），有则说明已滚动到第一页。
+        """
+        check_pos = self._profile.SCROLLBAR_TOP_CHECK_POS
+        try:
+            # 根据分辨率计算搜索半径（1080p 为 2，其他分辨率按比例缩放）
+            resolution = self._profile.RESOLUTION
+            scale_factor = resolution[1] / 1080
+            radius = max(1, round(2 * scale_factor))
+
+            roi = Region(
+                Point(check_pos.x - radius, check_pos.y - radius),
+                Point(check_pos.x + radius + 1, check_pos.y + radius + 1),
+            )
+            screenshot = self._image_source.screenshot(roi)
+
+            has_bright = bool(np.any(np.all(screenshot[:, :, :3] > 100, axis=2)))
+            if has_bright:
+                logger.debug(f"检测到滚动条顶部亮点 at ({check_pos.x}, {check_pos.y})")
+                return True
+
+            logger.debug(f"未检测到滚动条顶部亮点 at ({check_pos.x}, {check_pos.y})")
+            return False
+
+        except Exception as e:
+            logger.warning(f"滚动条顶部检测失败: {e}")
+            return False
+
+    def _reset_to_first_page(self, stop_event: threading.Event) -> bool:
+        """冗余清理：滚动条顶端 16px 上拖，配合顶部亮点检测回到第一页。
+
+        拖动距离恒定 16px（不随分辨率缩放，过小可能无法被游戏识别）；
+        起点随分辨率缩放。检测不到亮点时按已在第一页继续（重试耗尽后由
+        回访指纹校验兜底，单页背包可能无滚动条滑块）。
+        """
+        top = self._profile.SCROLLBAR_TOP_CHECK_POS
+        start = Point(top.x, top.y + _SCROLL_TOP_DRAG_PX)
+
+        if self._check_scrollbar_at_top():
+            logger.debug("冗余清理：已在第一页。")
+            return True
+
+        for attempt in range(1, 4):
+            if stop_event.is_set():
+                return False
+            self._window_actions.progressive_drag(
+                start.x,
+                start.y,
+                top.x,
+                top.y,
+                step=8,
+                max_drag=_SCROLL_TOP_DRAG_PX,
+            )
+            self._window_actions.wait(0.5)
+            if self._check_scrollbar_at_top():
+                logger.info(f"冗余清理：已回到第一页（第 {attempt} 次尝试）。")
+                return True
+
+        logger.warning("冗余清理：未检测到滚动条顶部亮点，按已在第一页继续。")
+        return True
+
+    def _advance_to_page(
+        self,
+        current_page: int,
+        target_page: int,
+        stop_event: threading.Event,
+        user_setting: UserSetting,
+    ) -> bool:
+        """冗余清理：从当前页向前翻页到目标页，完全复用扫描时的翻页机件。
+
+        与扫描翻页保持同一路径（渐进拖动 + 行末检测 + 暗带对齐），保证
+        回访页的网格行偏移与扫描时一致；提前检测到列表底部时停止翻页
+        （该位置即最后扫描页，目标页记录必然在其上）。
+        """
+        drag_start = self._profile.DRAG_START_POS
+        drag_end = self._profile.DRAG_END_POS
+        scrollbar_pos = self._profile.SCROLLBAR_CHECK_POS
+        icon_x_list = self._profile.essence_icon_x_list
+        icon_y_list = self._profile.essence_icon_y_list
+
+        row_height = icon_y_list[1] - icon_y_list[0] if len(icon_y_list) > 1 else 0
+        max_drag_distance = (
+            int((drag_end.x - drag_start.x) ** 2 + (drag_end.y - drag_start.y) ** 2)
+            ** 0.5
+        )
+
+        pages_remaining = target_page - current_page
+        for _ in range(pages_remaining):
+            if stop_event.is_set() or not self._window_actions.target_is_active:
+                logger.warning("冗余清理：翻页中止。")
+                return False
+            logger.debug("冗余清理：向前翻页。")
+            _distance, is_last_page = self._progressive_drag(
+                drag_start,
+                drag_end,
+                scrollbar_pos,
+                stop_event,
+                step=50,
+                max_drag=max_drag_distance,
+                row_height=row_height,
+            )
+            if is_last_page:
+                # 已到底部（最后扫描页）：与扫描时的翻页状态一致，停止翻页
+                break
+            if user_setting.fix_grid_row_offset_after_page_flip:
+                self._align_grid_rows_after_drag(drag_start, icon_x_list, icon_y_list)
+            if self._check_scrollbar_at_bottom(scrollbar_pos):
+                logger.debug("冗余清理：翻页后检测到滚动条到底。")
+                break
+        return True
 
     def _progressive_drag(
         self,
@@ -1467,16 +1906,6 @@ class DraggableScannerEngine(ScannerEngine):
         )
         return result
 
-    def _get_essence_hash(self, data: EssenceData) -> str:
-        """
-        生成基质指纹用于去重检测。
-
-        使用稀有度、属性类型和属性等级作为指纹。
-        """
-        stats_str = "_".join(str(s) if s is not None else "?" for s in data.stats)
-        levels_str = "_".join(str(lv) if lv is not None else "?" for lv in data.levels)
-        return f"{data.rarity.value}_{stats_str}_{levels_str}"
-
     def _scan_single_row(
         self,
         row_index: int,
@@ -1570,6 +1999,16 @@ class DraggableScannerEngine(ScannerEngine):
 
             if evaluation.quality != EssenceQuality.SKIP:
                 self._total_essence_count += 1
+
+            # 冗余清理（实验性）：记录本轮判为宝藏的基质
+            if self._cleanup_active and evaluation.quality == EssenceQuality.TREASURE:
+                self._record_cleanup_claim(
+                    claim_result,
+                    data,
+                    page=self._cleanup_page_index,
+                    row=row_index,
+                    col=j,
+                )
 
             # 同步认领结果到引擎
             for weapon_id, levels in claim_result.updated_levels.items():

--- a/src/endfield_essence_recognizer/core/scanner/models.py
+++ b/src/endfield_essence_recognizer/core/scanner/models.py
@@ -88,6 +88,32 @@ class RejectReason(StrEnum):
     """非降级原则过滤：无法升级任何匹配武器已有基质。"""
 
 
+class ClaimKind(StrEnum):
+    """认领路径类型。
+
+    供引擎的冗余清理做物理基质记录与"名额释放"判定：识别某枚物理基质
+    究竟占用了名额、替换了旧持有者、还是只是页面存量的实体被重扫。
+    """
+
+    NONE = "none"
+    """无认领（非宝藏 / 被拒绝 / 保留不落盘）。"""
+
+    NEW_SLOT = "new_slot"
+    """新增名额认领。"""
+
+    UPGRADE = "upgrade"
+    """替换已保存最优（释放旧持有者）。"""
+
+    SKIP_EXISTING = "skip_existing"
+    """存量跳过：宝藏页已记录基质的实体被重扫，不计新名额。"""
+
+    COUNT_ONLY = "count_only"
+    """仅计数（同等级占名额 / 等级不变同步计数）。"""
+
+    VIRTUAL_SLOT = "virtual_slot"
+    """按基质分组的虚拟槽认领（无武器归属）。"""
+
+
 @dataclass
 class ClassificationResult:
     """Layer 1 输出：纯分类结果，不含认领决策。"""
@@ -138,3 +164,12 @@ class ClaimResult:
 
     group_stat_key: tuple | None = None
     """属性组合 key（展示计数用）。"""
+
+    claim_kind: ClaimKind = ClaimKind.NONE
+    """认领路径类型，供冗余清理的物理基质记录与名额释放判定使用。"""
+
+    owner_key: str | tuple | None = None
+    """认领归属 key（武器 ID 或属性组合元组）；冗余判定按此分组。"""
+
+    released_levels: LevelTuple | None = None
+    """UPGRADE 时被释放的旧等级（用于定位被替换的物理基质记录）。"""

--- a/src/endfield_essence_recognizer/schemas/user_setting.py
+++ b/src/endfield_essence_recognizer/schemas/user_setting.py
@@ -88,6 +88,16 @@ class KeepBestMode(StrEnum):
     """概率和值：按升级难度加权比较（等级越高越难升，权重越大）。"""
 
 
+class CleanupTriggerMode(StrEnum):
+    """冗余清理（实验性）的触发时机。"""
+
+    SCAN_COMPLETE = "scan_complete"
+    """仅在扫描到尾页（自然完成）时清理。"""
+
+    ALWAYS = "always"
+    """所有情况下均清理（含手动停止扫描）。"""
+
+
 class EssenceStats(BaseModel):
     """自定义宝藏基质属性组合，支持可选的显示名称。"""
 
@@ -111,7 +121,7 @@ class EssenceStats(BaseModel):
 
 
 class UserSetting(BaseModel):
-    _VERSION: ClassVar[int] = 8
+    _VERSION: ClassVar[int] = 9
     _same_type_treasure_counts: dict[tuple[str | None, ...], int] = PrivateAttr(
         default_factory=dict
     )
@@ -194,6 +204,15 @@ class UserSetting(BaseModel):
 
     same_type_keep_best_mode: KeepBestMode = KeepBestMode.SUM
     """留大弃小策略中等级比较的方式：依次比对 / 和值比对 / 概率和值。"""
+
+    redundant_cleanup_enabled: bool = False
+    """冗余清理（实验性）总开关；关闭时不产生任何记录与额外操作。"""
+
+    redundant_cleanup_trigger: CleanupTriggerMode = CleanupTriggerMode.SCAN_COMPLETE
+    """冗余清理的触发时机：仅在扫描到尾页时 / 所有情况下（含手动停止）。"""
+
+    redundant_action: Action = Action.DEPRECATE
+    """对判定为冗余的基质执行的操作（「基质操作规则」中「对于冗余基质」）。"""
 
     auto_page_flip: bool = True
     """扫描时是否自动翻页"""
@@ -335,6 +354,13 @@ class UserSetting(BaseModel):
                 entry["id"] = uuid4().hex
             seen.add(entry["id"])
 
+    @staticmethod
+    def _migrate_v8_to_v9(data: dict) -> None:
+        """v8 → v9: 添加冗余清理（实验性）设置，默认关闭。"""
+        data.setdefault("redundant_cleanup_enabled", False)
+        data.setdefault("redundant_cleanup_trigger", "scan_complete")
+        data.setdefault("redundant_action", "deprecate")
+
     # 迁移函数映射表：版本号 -> 迁移函数
     # 使用 __func__ 提取底层函数，避免存储 staticmethod 对象（兼容性更好）
     _MIGRATIONS: ClassVar[dict[int, Any]] = {
@@ -344,6 +370,7 @@ class UserSetting(BaseModel):
         5: _migrate_v5_to_v6.__func__,
         6: _migrate_v6_to_v7.__func__,
         7: _migrate_v7_to_v8.__func__,
+        8: _migrate_v8_to_v9.__func__,
     }
 
     @classmethod

--- a/src/endfield_essence_recognizer/services/scanner_service.py
+++ b/src/endfield_essence_recognizer/services/scanner_service.py
@@ -120,6 +120,14 @@ class ScannerService:
                     # 扫描完成后保存数据并同步（无论是正常完成还是被中断）
                     # 使用保存的引擎引用，而不是 self._current_engine
                     self._on_scan_complete(engine_ref)
+                    # 线程退出后复位停止状态。手动停止后紧接着的冗余清理会
+                    # 清除停止事件继续运行，停止标记必须在线程真正结束时复位，
+                    # 否则 is_running 会永远为 True、后续扫描被拒。
+                    with self._lock:
+                        if self._thread is threading.current_thread():
+                            self._thread = None
+                            self._current_engine = None
+                        self._stopping = False
 
             self._thread = threading.Thread(
                 target=wrapped_execute,

--- a/tests/test_user_setting_manager.py
+++ b/tests/test_user_setting_manager.py
@@ -325,6 +325,9 @@ def test_user_setting_schema_stability():
         "same_type_keep_best",
         "same_type_keep_best_mode",
         "same_type_non_downgrade_filter",
+        "redundant_cleanup_enabled",
+        "redundant_cleanup_trigger",
+        "redundant_action",
         "auto_page_flip",
         "fix_grid_row_offset_after_page_flip",
         "fix_page_flip_overscroll",
@@ -531,6 +534,30 @@ def test_migration_sets_all_required_fields():
 
     # v6→v7 补充的字段（留大弃小等级比较方式）
     assert migrated.same_type_keep_best_mode == "sum"
+
+    # v8→v9 补充的字段（冗余清理，默认关闭）
+    assert migrated.redundant_cleanup_enabled is False
+    assert migrated.redundant_cleanup_trigger == "scan_complete"
+    assert migrated.redundant_action == "deprecate"
+
+
+def test_migrate_v8_to_v9_adds_redundant_cleanup_fields():
+    """v8 → v9: 补充冗余清理字段，默认关闭，已有字段保留。"""
+    v8_config = {
+        "version": 8,
+        "trash_weapon_ids": ["w1"],
+        "same_type_treasure_limit_enabled": True,
+        "same_type_treasure_limit": 2,
+    }
+
+    migrated = UserSetting.migrate_from_old_version(v8_config)
+
+    assert migrated.version == UserSetting._VERSION
+    assert migrated.trash_weapon_ids == ["w1"]
+    assert migrated.same_type_treasure_limit == 2
+    assert migrated.redundant_cleanup_enabled is False
+    assert migrated.redundant_cleanup_trigger == "scan_complete"
+    assert migrated.redundant_action == "deprecate"
 
 
 def test_legacy_cn_update_mirror_normalizes_to_yituliu_flow():

--- a/tests/unit/core/scanner/test_action_logic.py
+++ b/tests/unit/core/scanner/test_action_logic.py
@@ -187,4 +187,63 @@ def test_decide_actions_skip_quality(default_data, default_eval, default_setting
     default_eval.quality = EssenceQuality.SKIP
     actions = decide_actions(default_data, default_eval, default_settings)
     assert actions == []
+
+
+def test_target_action_override_deprecate(default_data, default_eval, default_settings):
+    """
+    冗余清理：target_action 覆盖生效——即使 trash_action=unlock，
+    显式传入 DEPRECATE 也按弃用处理。
+    """
+    default_eval.quality = EssenceQuality.TRASH
+    default_settings.trash_action = Action.UNLOCK
+    default_data.lock_label = LockStatusLabel.LOCKED
+    default_data.abandon_label = AbandonStatusLabel.NOT_ABANDONED
+
+    actions = decide_actions(
+        default_data,
+        default_eval,
+        default_settings,
+        target_action=Action.DEPRECATE,
+    )
+    assert len(actions) == 1
+    assert actions[0].type == ActionType.CLICK_ABANDON
+
+
+def test_target_action_override_unlock(default_data, default_eval, default_settings):
+    """
+    冗余清理：target_action=UNLOCK 时，已锁定的基质被解锁。
+    """
+    default_eval.quality = EssenceQuality.TRASH
+    default_settings.trash_action = Action.DEPRECATE
+    default_data.lock_label = LockStatusLabel.LOCKED
+    default_data.abandon_label = AbandonStatusLabel.NOT_ABANDONED
+
+    actions = decide_actions(
+        default_data,
+        default_eval,
+        default_settings,
+        target_action=Action.UNLOCK,
+    )
+    assert len(actions) == 1
+    assert actions[0].type == ActionType.CLICK_LOCK
+
+
+def test_target_action_override_keep_no_effect(
+    default_data, default_eval, default_settings
+):
+    """
+    冗余清理：target_action=KEEP 时不产生任何动作。
+    """
+    default_eval.quality = EssenceQuality.TREASURE
+    default_settings.treasure_action = Action.LOCK
+    default_data.lock_label = LockStatusLabel.NOT_LOCKED
+    default_data.abandon_label = AbandonStatusLabel.NOT_ABANDONED
+
+    actions = decide_actions(
+        default_data,
+        default_eval,
+        default_settings,
+        target_action=Action.KEEP,
+    )
+    assert actions == []
     assert len(actions) == 0

--- a/tests/unit/core/scanner/test_cleanup.py
+++ b/tests/unit/core/scanner/test_cleanup.py
@@ -102,7 +102,10 @@ class MockWindowActions:
 @pytest.fixture
 def mock_scanner_context():
     ui_scene_recognizer = MagicMock(spec=TemplateRecognizer)
-    ui_scene_recognizer.recognize_roi_fallback.return_value = (UISceneLabel.ESSENCE_UI, 1.0)
+    ui_scene_recognizer.recognize_roi_fallback.return_value = (
+        UISceneLabel.ESSENCE_UI,
+        1.0,
+    )
 
     attr_recognizer = MagicMock(spec=TemplateRecognizer)
     attr_recognizer.recognize_roi.return_value = ("atk", 0.9)
@@ -208,7 +211,9 @@ class TestRecordCleanupClaim:
     def test_new_slot_appends_designated(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         data = make_data([4, 4, 2])
         engine._record_cleanup_claim(
             ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
@@ -229,7 +234,9 @@ class TestRecordCleanupClaim:
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
         """识别位置顺序不等于语义顺序时，记录等级必须归一化为（属性, 副属性, 技能）。"""
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         data = EssenceData(
             stats=["C", "A", "B"],
             stat_types=[StatType.SKILL, StatType.ATTRIBUTE, StatType.SECONDARY],
@@ -250,7 +257,9 @@ class TestRecordCleanupClaim:
     def test_upgrade_releases_previous_holder(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._record_cleanup_claim(
             ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
             make_data([4, 4, 2]),
@@ -280,7 +289,9 @@ class TestRecordCleanupClaim:
     def test_cascade_transfers_released_record(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._record_cleanup_claim(
             ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
             make_data([4, 4, 2]),
@@ -312,7 +323,9 @@ class TestRecordCleanupClaim:
     def test_skip_existing_and_count_only_stay_designated(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._record_cleanup_claim(
             ClaimResult(claim_kind=ClaimKind.SKIP_EXISTING, owner_key="wpn_A"),
             make_data([6, 6, 3]),
@@ -332,7 +345,9 @@ class TestRecordCleanupClaim:
     def test_none_kind_is_ignored(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._record_cleanup_claim(
             ClaimResult(claim_kind=ClaimKind.NONE),
             make_data([4, 4, 2]),
@@ -343,6 +358,57 @@ class TestRecordCleanupClaim:
         assert engine._cleanup_records == []
         assert engine._cleanup_designated == {}
 
+    def test_records_rollback_truncates_since_snapshot(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """过冲检测首行 pass 的记录可整体回滚，不再参与冗余判定。"""
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
+            make_data([4, 4, 2]),
+            page=1,
+            row=0,
+            col=0,
+        )
+        snapshot = engine._cleanup_records_snapshot()
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_B"),
+            make_data([6, 6, 3]),
+            page=1,
+            row=1,
+            col=0,
+        )
+        assert len(engine._cleanup_records) == 2
+
+        engine._cleanup_records_rollback(snapshot)
+
+        assert len(engine._cleanup_records) == 1
+        assert engine._cleanup_records[0].owner == "wpn_A"
+        # 被回滚的记录不再参与判定（判定只遍历 _cleanup_records）
+        kept_ids = {id(r) for rs in engine._cleanup_designated.values() for r in rs}
+        redundant = [r for r in engine._cleanup_records if id(r) not in kept_ids]
+        assert redundant == []
+
+    def test_init_cleanup_state_resets_navigation_state(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_flipped_pages = True
+        engine._cleanup_corrected_pages = {2}
+        engine._cleanup_max_page = 5
+
+        setting = UserSetting()
+        setting.redundant_cleanup_enabled = True
+        engine._init_cleanup_state(setting)
+
+        assert engine._cleanup_flipped_pages is False
+        assert engine._cleanup_corrected_pages == set()
+        assert engine._cleanup_max_page == 1
+
 
 # ── 触发模式 ──
 
@@ -351,7 +417,9 @@ class TestMaybeRunCleanup:
     def test_scan_complete_trigger_skips_manual_stop(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._run_cleanup = MagicMock()
         stop_event = threading.Event()
         stop_event.set()
@@ -366,7 +434,9 @@ class TestMaybeRunCleanup:
     def test_always_trigger_clears_stop_event_and_runs(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._run_cleanup = MagicMock()
         stop_event = threading.Event()
         stop_event.set()
@@ -381,7 +451,9 @@ class TestMaybeRunCleanup:
     def test_natural_completion_runs_with_scan_complete_trigger(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._run_cleanup = MagicMock()
         stop_event = threading.Event()
 
@@ -395,7 +467,9 @@ class TestMaybeRunCleanup:
     def test_inactive_cleanup_never_runs(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         engine._cleanup_active = False
         engine._run_cleanup = MagicMock()
         engine._maybe_run_cleanup(True, threading.Event(), UserSetting())
@@ -409,7 +483,9 @@ class TestRunCleanup:
     def test_judges_redundant_and_visits_by_page(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         kept = make_record(1, 0, 0, (6, 5, 3), "wpn_A")
         redundant_p1 = make_record(1, 1, 0, (4, 4, 2), "wpn_A")
         redundant_p3 = make_record(3, 2, 1, (3, 3, 1), "wpn_A")
@@ -428,7 +504,9 @@ class TestRunCleanup:
     def test_no_redundant_logs_and_skips_navigation(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         kept = make_record(1, 0, 0, (6, 5, 3), "wpn_A")
         engine._cleanup_records = [kept]
         engine._cleanup_designated = {"wpn_A": [kept]}
@@ -441,7 +519,9 @@ class TestRunCleanup:
     def test_page_mismatch_aborts_cleanup(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         redundant_p1 = make_record(1, 0, 0, (4, 4, 2), "wpn_A")
         redundant_p2 = make_record(2, 0, 0, (3, 3, 1), "wpn_A")
         engine._cleanup_records = [redundant_p1, redundant_p2]
@@ -466,7 +546,9 @@ class TestVisitCleanupRecords:
     def test_matching_record_deprecates_by_redundant_action(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         fingerprint = self._recognized_fingerprint(engine)
         record = make_record(1, 0, 0, (4, 4, 2), "wpn_A", fingerprint=fingerprint)
 
@@ -485,7 +567,9 @@ class TestVisitCleanupRecords:
     def test_matching_record_unlocks_when_locked(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         mock_scanner_context.lock_status_recognizer.recognize_roi_fallback.return_value = (
             LockStatusLabel.LOCKED,
             0.9,
@@ -507,7 +591,9 @@ class TestVisitCleanupRecords:
     def test_fingerprint_mismatch_page_returns_page_mismatch(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         record = make_record(1, 0, 0, (4, 4, 2), "wpn_A", fingerprint="不匹配的指纹")
 
         outcome = engine._visit_cleanup_records(
@@ -521,7 +607,9 @@ class TestVisitCleanupRecords:
     def test_stop_event_aborts(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
-        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine = build_engine(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
         stop_event = threading.Event()
         stop_event.set()
         record = make_record(1, 0, 0, (4, 4, 2), "wpn_A")
@@ -536,7 +624,9 @@ class TestVisitCleanupRecords:
 
 
 class TestDraggableNavigation:
-    def build_draggable(self, mock_scanner_context, mock_user_setting_manager, mock_profile):
+    def build_draggable(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
         engine = DraggableScannerEngine(
             ctx=mock_scanner_context,
             image_source=MockImageSource(),
@@ -554,29 +644,46 @@ class TestDraggableNavigation:
         engine = self.build_draggable(
             mock_scanner_context, mock_user_setting_manager, mock_profile
         )
-        # 顶部亮点一直检测不到 → 走满 3 次拖动手势后按已回顶继续
+        # 翻过页且顶部亮点一直检测不到 → 走满 3 次拖动手势后放弃清理
+        engine._cleanup_flipped_pages = True
         engine._check_scrollbar_at_top = MagicMock(return_value=False)
 
         result = engine._reset_to_first_page(threading.Event())
 
-        assert result is True
+        assert result is False
         assert len(engine._window_actions.drag_calls) == 3
         # 拖动距离恒定 16px：起点 top+16 → 终点 top
         start_x, start_y, end_x, end_y, *_ = engine._window_actions.drag_calls[0]
         assert (start_x, start_y) == (1453, 146)
         assert (end_x, end_y) == (1453, 130)
 
-    def test_reset_to_first_page_skips_drag_when_already_at_top(
+    def test_reset_to_first_page_succeeds_when_top_confirmed(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
         mock_profile.SCROLLBAR_TOP_CHECK_POS = Point(1453, 130)
         engine = self.build_draggable(
             mock_scanner_context, mock_user_setting_manager, mock_profile
         )
+        engine._cleanup_flipped_pages = True
         engine._check_scrollbar_at_top = MagicMock(return_value=True)
 
         assert engine._reset_to_first_page(threading.Event()) is True
         assert engine._window_actions.drag_calls == []
+
+    def test_reset_to_first_page_skips_check_when_never_flipped(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """本轮从未翻页时物理上就在第一页，无需顶部检测。"""
+        mock_profile.SCROLLBAR_TOP_CHECK_POS = Point(1453, 130)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_flipped_pages = False
+        engine._check_scrollbar_at_top = MagicMock(return_value=False)
+
+        assert engine._reset_to_first_page(threading.Event()) is True
+        assert engine._window_actions.drag_calls == []
+        engine._check_scrollbar_at_top.assert_not_called()
 
     def test_advance_to_page_flips_difference(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
@@ -601,7 +708,7 @@ class TestDraggableNavigation:
         assert engine._progressive_drag.call_count == 2
         assert engine._align_grid_rows_after_drag.call_count == 2
 
-    def test_advance_to_page_stops_at_bottom(
+    def test_advance_to_page_stops_at_bottom_when_target_is_last_scanned(
         self, mock_scanner_context, mock_user_setting_manager, mock_profile
     ):
         mock_profile.DRAG_START_POS = Point(750, 870)
@@ -610,6 +717,7 @@ class TestDraggableNavigation:
         engine = self.build_draggable(
             mock_scanner_context, mock_user_setting_manager, mock_profile
         )
+        engine._cleanup_max_page = 4
         engine._progressive_drag = MagicMock(return_value=(600, True))
         engine._align_grid_rows_after_drag = MagicMock()
 
@@ -619,6 +727,94 @@ class TestDraggableNavigation:
         # 检测到到底后不再翻页、不再对齐
         assert engine._progressive_drag.call_count == 1
         assert engine._align_grid_rows_after_drag.call_count == 0
+
+    def test_advance_to_page_aborts_when_bottom_reached_before_target(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """提前到达底部但目标页不是最后扫描页 → 翻页序列发散，放弃清理。"""
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_max_page = 5
+        engine._progressive_drag = MagicMock(return_value=(600, True))
+        engine._align_grid_rows_after_drag = MagicMock()
+
+        result = engine._advance_to_page(1, 3, threading.Event(), UserSetting())
+
+        assert result is False
+        assert engine._progressive_drag.call_count == 1
+        assert engine._align_grid_rows_after_drag.call_count == 0
+
+    def test_advance_to_page_aborts_on_post_flip_bottom_before_target(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """翻页后检测到底部但目标页不是最后扫描页 → 放弃清理。"""
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_max_page = 5
+        engine._progressive_drag = MagicMock(return_value=(820, False))
+        engine._align_grid_rows_after_drag = MagicMock()
+        engine._check_scrollbar_at_bottom = MagicMock(return_value=True)
+
+        result = engine._advance_to_page(1, 3, threading.Event(), UserSetting())
+
+        assert result is False
+        assert engine._progressive_drag.call_count == 1
+
+    def test_advance_to_page_replays_overscroll_correction(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """扫描期做过过冲校正的页，清理导航到达后重放同参数的 3/4 行校正。"""
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        mock_profile.essence_icon_y_list = [196, 351]
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_max_page = 3
+        engine._cleanup_corrected_pages = {2}
+        engine._progressive_drag = MagicMock(return_value=(820, False))
+        engine._align_grid_rows_after_drag = MagicMock()
+        engine._check_scrollbar_at_bottom = MagicMock(return_value=False)
+        engine._correct_overscroll = MagicMock()
+
+        result = engine._advance_to_page(1, 2, threading.Event(), UserSetting())
+
+        assert result is True
+        row_height = 351 - 196
+        engine._correct_overscroll.assert_called_once_with(
+            Point(750, 870), round(row_height * 3 / 4)
+        )
+
+    def test_advance_to_page_skips_correction_for_other_pages(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        mock_profile.essence_icon_y_list = [196, 351]
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._cleanup_max_page = 3
+        engine._cleanup_corrected_pages = {2}
+        engine._progressive_drag = MagicMock(return_value=(820, False))
+        engine._align_grid_rows_after_drag = MagicMock()
+        engine._check_scrollbar_at_bottom = MagicMock(return_value=False)
+        engine._correct_overscroll = MagicMock()
+
+        result = engine._advance_to_page(1, 3, threading.Event(), UserSetting())
+
+        assert result is True
+        engine._correct_overscroll.assert_not_called()
 
 
 # ── claimer 路径标注 ──

--- a/tests/unit/core/scanner/test_cleanup.py
+++ b/tests/unit/core/scanner/test_cleanup.py
@@ -1,0 +1,751 @@
+"""冗余清理（实验性）：记录、名额账本、判定与回访动作的单元测试。"""
+
+import threading
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from endfield_essence_recognizer.core.layout.base import (
+    Point,
+    Region,
+    ResolutionProfile,
+)
+from endfield_essence_recognizer.core.recognition import (
+    AbandonStatusLabel,
+    AttributeLevelRecognizer,
+    LockStatusLabel,
+    RarityLabel,
+)
+from endfield_essence_recognizer.core.recognition.tasks.ui import UISceneLabel
+from endfield_essence_recognizer.core.recognition.template_recognizer import (
+    TemplateRecognizer,
+)
+from endfield_essence_recognizer.core.scanner.claimer import ClaimContext
+from endfield_essence_recognizer.core.scanner.classifier import classify_essence
+from endfield_essence_recognizer.core.scanner.context import ScannerContext
+from endfield_essence_recognizer.core.scanner.engine import (
+    DraggableScannerEngine,
+    ScannerEngine,
+    _CleanupRecord,
+)
+from endfield_essence_recognizer.core.scanner.models import (
+    ClaimKind,
+    ClaimResult,
+    EssenceData,
+)
+from endfield_essence_recognizer.game_data.models.v2 import EssenceStatV2, StatType
+from endfield_essence_recognizer.schemas.profile import TreasureMatrixEntry
+from endfield_essence_recognizer.schemas.user_setting import (
+    Action,
+    CleanupTriggerMode,
+    SameTypeGroupMode,
+    UserSetting,
+)
+from endfield_essence_recognizer.services.user_setting_manager import UserSettingManager
+
+# ── 模拟依赖 ──
+
+
+class MockImageSource:
+    def __init__(self, width: int = 1920, height: int = 1080):
+        self.width = width
+        self.height = height
+
+    def get_client_size(self) -> tuple[int, int]:
+        return self.width, self.height
+
+    def screenshot(self, relative_region: Region | None = None) -> np.ndarray:
+        if relative_region is not None:
+            w = relative_region.x1 - relative_region.x0
+            h = relative_region.y1 - relative_region.y0
+        else:
+            w, h = self.width, self.height
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+class MockWindowActions:
+    def __init__(self):
+        self._target_exists = True
+        self._target_is_active = True
+        self.click_calls: list[tuple[int, int]] = []
+        self.drag_calls: list[tuple] = []
+
+    @property
+    def target_exists(self) -> bool:
+        return self._target_exists
+
+    @property
+    def target_is_active(self) -> bool:
+        return self._target_is_active
+
+    def restore(self) -> bool:
+        return True
+
+    def activate(self) -> bool:
+        return True
+
+    def show(self) -> bool:
+        return True
+
+    def click(self, relative_x: int, relative_y: int) -> None:
+        self.click_calls.append((relative_x, relative_y))
+
+    def wait(self, seconds: float) -> None:
+        pass
+
+    def progressive_drag(self, *args, **kwargs) -> tuple[int, bool]:
+        self.drag_calls.append(args)
+        return (kwargs.get("max_drag", 0), False)
+
+
+@pytest.fixture
+def mock_scanner_context():
+    ui_scene_recognizer = MagicMock(spec=TemplateRecognizer)
+    ui_scene_recognizer.recognize_roi_fallback.return_value = (UISceneLabel.ESSENCE_UI, 1.0)
+
+    attr_recognizer = MagicMock(spec=TemplateRecognizer)
+    attr_recognizer.recognize_roi.return_value = ("atk", 0.9)
+
+    attr_level_recognizer = MagicMock(spec=AttributeLevelRecognizer)
+    attr_level_recognizer.recognize_level.return_value = 10
+
+    abandon_status_recognizer = MagicMock(spec=TemplateRecognizer)
+    abandon_status_recognizer.recognize_roi_fallback.return_value = (
+        AbandonStatusLabel.NOT_ABANDONED,
+        0.9,
+    )
+
+    lock_status_recognizer = MagicMock(spec=TemplateRecognizer)
+    lock_status_recognizer.recognize_roi_fallback.return_value = (
+        LockStatusLabel.NOT_LOCKED,
+        0.9,
+    )
+
+    rarity_recognizer = MagicMock(spec=TemplateRecognizer)
+    rarity_recognizer.recognize_roi_fallback.return_value = (RarityLabel.OTHER, 0.9)
+
+    static_game_data = MagicMock()
+    static_game_data.get_stat.return_value = MagicMock(name="TestStat")
+    static_game_data.list_weapons.return_value = []
+    static_game_data.get_weapon.return_value = None
+
+    return ScannerContext(
+        attr_recognizer=attr_recognizer,
+        attr_level_recognizer=attr_level_recognizer,
+        abandon_status_recognizer=abandon_status_recognizer,
+        lock_status_recognizer=lock_status_recognizer,
+        rarity_recognizer=rarity_recognizer,
+        ui_scene_recognizer=ui_scene_recognizer,
+        static_game_data=static_game_data,
+    )
+
+
+@pytest.fixture
+def mock_profile():
+    profile = MagicMock(spec=ResolutionProfile)
+    profile.RESOLUTION = (1920, 1080)
+    profile.ESSENCE_UI_ROI = Region(Point(38, 66), Point(143, 106))
+    profile.STATS_0_ROI = Region(Point(1508, 358), Point(1700, 390))
+    profile.STATS_1_ROI = Region(Point(1508, 416), Point(1700, 448))
+    profile.STATS_2_ROI = Region(Point(1508, 468), Point(1700, 500))
+    profile.DEPRECATE_BUTTON_ROI = Region(Point(1790, 270), Point(1823, 302))
+    profile.LOCK_BUTTON_ROI = Region(Point(1825, 270), Point(1857, 302))
+    profile.LOCK_BUTTON_POS = Point(1839, 286)
+    profile.DEPRECATE_BUTTON_POS = Point(1807, 284)
+    profile.essence_icon_x_list = [100, 200]
+    profile.essence_icon_y_list = [300, 400]
+    return profile
+
+
+@pytest.fixture
+def mock_user_setting_manager():
+    manager = MagicMock(spec=UserSettingManager)
+    manager.get_user_setting.return_value = UserSetting()
+    return manager
+
+
+def build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile):
+    engine = ScannerEngine(
+        ctx=mock_scanner_context,
+        image_source=MockImageSource(),
+        window_actions=MockWindowActions(),
+        user_setting_manager=mock_user_setting_manager,
+        profile=mock_profile,
+    )
+    engine._cleanup_active = True
+    return engine
+
+
+def make_data(levels: list[int | None]) -> EssenceData:
+    return EssenceData(
+        stats=["A", "B", "C"],
+        stat_types=[StatType.ATTRIBUTE, StatType.SECONDARY, StatType.SKILL],
+        levels=levels,
+        rarity=RarityLabel.FIVE,
+        abandon_label=AbandonStatusLabel.NOT_ABANDONED,
+        lock_label=LockStatusLabel.NOT_LOCKED,
+    )
+
+
+def make_record(
+    page: int,
+    row: int,
+    col: int,
+    levels: tuple[int, int, int],
+    owner: str,
+    fingerprint: str = "fp",
+) -> _CleanupRecord:
+    return _CleanupRecord(
+        page=page, row=row, col=col, levels=levels, fingerprint=fingerprint, owner=owner
+    )
+
+
+# ── 记录与名额账本 ──
+
+
+class TestRecordCleanupClaim:
+    def test_new_slot_appends_designated(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        data = make_data([4, 4, 2])
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
+            data,
+            page=1,
+            row=0,
+            col=0,
+        )
+
+        assert len(engine._cleanup_records) == 1
+        record = engine._cleanup_records[0]
+        assert record.levels == (4, 4, 2)
+        assert record.owner == "wpn_A"
+        assert record.fingerprint == engine._get_essence_hash(data)
+        assert engine._cleanup_designated["wpn_A"] == [record]
+
+    def test_record_levels_normalized_to_semantic_order(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        """识别位置顺序不等于语义顺序时，记录等级必须归一化为（属性, 副属性, 技能）。"""
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        data = EssenceData(
+            stats=["C", "A", "B"],
+            stat_types=[StatType.SKILL, StatType.ATTRIBUTE, StatType.SECONDARY],
+            levels=[3, 6, 6],
+            rarity=RarityLabel.FIVE,
+            abandon_label=AbandonStatusLabel.NOT_ABANDONED,
+            lock_label=LockStatusLabel.NOT_LOCKED,
+        )
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
+            data,
+            page=1,
+            row=0,
+            col=0,
+        )
+        assert engine._cleanup_records[0].levels == (6, 6, 3)
+
+    def test_upgrade_releases_previous_holder(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
+            make_data([4, 4, 2]),
+            page=1,
+            row=0,
+            col=0,
+        )
+        engine._record_cleanup_claim(
+            ClaimResult(
+                claim_kind=ClaimKind.UPGRADE,
+                owner_key="wpn_A",
+                released_levels=(4, 4, 2),
+            ),
+            make_data([6, 5, 3]),
+            page=1,
+            row=1,
+            col=0,
+        )
+
+        designated = engine._cleanup_designated["wpn_A"]
+        assert [r.levels for r in designated] == [(6, 5, 3)]
+
+        kept_ids = {id(r) for rs in engine._cleanup_designated.values() for r in rs}
+        redundant = [r for r in engine._cleanup_records if id(r) not in kept_ids]
+        assert [r.levels for r in redundant] == [(4, 4, 2)]
+
+    def test_cascade_transfers_released_record(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NEW_SLOT, owner_key="wpn_A"),
+            make_data([4, 4, 2]),
+            page=1,
+            row=0,
+            col=0,
+        )
+        engine._record_cleanup_claim(
+            ClaimResult(
+                claim_kind=ClaimKind.UPGRADE,
+                owner_key="wpn_A",
+                released_levels=(4, 4, 2),
+                cascade_updated={"wpn_B": (4, 4, 2)},
+            ),
+            make_data([6, 5, 3]),
+            page=1,
+            row=1,
+            col=0,
+        )
+
+        assert [r.levels for r in engine._cleanup_designated["wpn_A"]] == [(6, 5, 3)]
+        transferred = engine._cleanup_designated["wpn_B"]
+        assert [r.levels for r in transferred] == [(4, 4, 2)]
+        assert transferred[0].owner == "wpn_B"
+
+        kept_ids = {id(r) for rs in engine._cleanup_designated.values() for r in rs}
+        assert all(id(r) in kept_ids for r in engine._cleanup_records)
+
+    def test_skip_existing_and_count_only_stay_designated(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.SKIP_EXISTING, owner_key="wpn_A"),
+            make_data([6, 6, 3]),
+            page=1,
+            row=0,
+            col=0,
+        )
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.COUNT_ONLY, owner_key="wpn_A"),
+            make_data([6, 6, 3]),
+            page=1,
+            row=1,
+            col=0,
+        )
+        assert len(engine._cleanup_designated["wpn_A"]) == 2
+
+    def test_none_kind_is_ignored(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._record_cleanup_claim(
+            ClaimResult(claim_kind=ClaimKind.NONE),
+            make_data([4, 4, 2]),
+            page=1,
+            row=0,
+            col=0,
+        )
+        assert engine._cleanup_records == []
+        assert engine._cleanup_designated == {}
+
+
+# ── 触发模式 ──
+
+
+class TestMaybeRunCleanup:
+    def test_scan_complete_trigger_skips_manual_stop(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._run_cleanup = MagicMock()
+        stop_event = threading.Event()
+        stop_event.set()
+
+        setting = UserSetting()
+        setting.redundant_cleanup_trigger = CleanupTriggerMode.SCAN_COMPLETE
+        engine._maybe_run_cleanup(False, stop_event, setting)
+
+        engine._run_cleanup.assert_not_called()
+        assert stop_event.is_set()
+
+    def test_always_trigger_clears_stop_event_and_runs(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._run_cleanup = MagicMock()
+        stop_event = threading.Event()
+        stop_event.set()
+
+        setting = UserSetting()
+        setting.redundant_cleanup_trigger = CleanupTriggerMode.ALWAYS
+        engine._maybe_run_cleanup(False, stop_event, setting)
+
+        engine._run_cleanup.assert_called_once()
+        assert not stop_event.is_set()
+
+    def test_natural_completion_runs_with_scan_complete_trigger(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._run_cleanup = MagicMock()
+        stop_event = threading.Event()
+
+        setting = UserSetting()
+        setting.redundant_cleanup_trigger = CleanupTriggerMode.SCAN_COMPLETE
+        engine._maybe_run_cleanup(True, stop_event, setting)
+
+        engine._run_cleanup.assert_called_once()
+        assert not stop_event.is_set()
+
+    def test_inactive_cleanup_never_runs(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        engine._cleanup_active = False
+        engine._run_cleanup = MagicMock()
+        engine._maybe_run_cleanup(True, threading.Event(), UserSetting())
+        engine._run_cleanup.assert_not_called()
+
+
+# ── 判定与回访 ──
+
+
+class TestRunCleanup:
+    def test_judges_redundant_and_visits_by_page(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        kept = make_record(1, 0, 0, (6, 5, 3), "wpn_A")
+        redundant_p1 = make_record(1, 1, 0, (4, 4, 2), "wpn_A")
+        redundant_p3 = make_record(3, 2, 1, (3, 3, 1), "wpn_A")
+        engine._cleanup_records = [kept, redundant_p1, redundant_p3]
+        engine._cleanup_designated = {"wpn_A": [kept]}
+
+        visited: list[list[_CleanupRecord]] = []
+        engine._visit_cleanup_records = MagicMock(
+            side_effect=lambda records, *_a, **_k: visited.append(records) or "done"
+        )
+
+        engine._run_cleanup(threading.Event(), UserSetting())
+
+        assert visited == [[redundant_p1], [redundant_p3]]
+
+    def test_no_redundant_logs_and_skips_navigation(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        kept = make_record(1, 0, 0, (6, 5, 3), "wpn_A")
+        engine._cleanup_records = [kept]
+        engine._cleanup_designated = {"wpn_A": [kept]}
+        engine._visit_cleanup_records = MagicMock()
+
+        engine._run_cleanup(threading.Event(), UserSetting())
+
+        engine._visit_cleanup_records.assert_not_called()
+
+    def test_page_mismatch_aborts_cleanup(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        redundant_p1 = make_record(1, 0, 0, (4, 4, 2), "wpn_A")
+        redundant_p2 = make_record(2, 0, 0, (3, 3, 1), "wpn_A")
+        engine._cleanup_records = [redundant_p1, redundant_p2]
+        engine._cleanup_designated = {}
+
+        engine._visit_cleanup_records = MagicMock(return_value="page_mismatch")
+
+        engine._run_cleanup(threading.Event(), UserSetting())
+
+        # 第一页全部不匹配 → 放弃，第二页不再回访
+        assert engine._visit_cleanup_records.call_count == 1
+
+
+class TestVisitCleanupRecords:
+    def _recognized_fingerprint(self, engine) -> str:
+        """与 mock 识别器一致的指纹：stats atk×3, levels 10×3, rarity OTHER。"""
+        from endfield_essence_recognizer.core.scanner.engine import recognize_essence
+
+        data = recognize_essence(engine._image_source, engine.ctx, engine._profile)
+        return engine._get_essence_hash(data)
+
+    def test_matching_record_deprecates_by_redundant_action(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        fingerprint = self._recognized_fingerprint(engine)
+        record = make_record(1, 0, 0, (4, 4, 2), "wpn_A", fingerprint=fingerprint)
+
+        setting = UserSetting()
+        setting.redundant_action = Action.DEPRECATE
+
+        outcome = engine._visit_cleanup_records([record], threading.Event(), setting)
+
+        assert outcome == "done"
+        # 点击基质 + 点击弃用按钮
+        assert engine._window_actions.click_calls[-1] == (
+            mock_profile.DEPRECATE_BUTTON_POS.x,
+            mock_profile.DEPRECATE_BUTTON_POS.y,
+        )
+
+    def test_matching_record_unlocks_when_locked(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        mock_scanner_context.lock_status_recognizer.recognize_roi_fallback.return_value = (
+            LockStatusLabel.LOCKED,
+            0.9,
+        )
+        fingerprint = self._recognized_fingerprint(engine)
+        record = make_record(1, 0, 0, (4, 4, 2), "wpn_A", fingerprint=fingerprint)
+
+        setting = UserSetting()
+        setting.redundant_action = Action.UNLOCK
+
+        outcome = engine._visit_cleanup_records([record], threading.Event(), setting)
+
+        assert outcome == "done"
+        assert engine._window_actions.click_calls[-1] == (
+            mock_profile.LOCK_BUTTON_POS.x,
+            mock_profile.LOCK_BUTTON_POS.y,
+        )
+
+    def test_fingerprint_mismatch_page_returns_page_mismatch(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        record = make_record(1, 0, 0, (4, 4, 2), "wpn_A", fingerprint="不匹配的指纹")
+
+        outcome = engine._visit_cleanup_records(
+            [record], threading.Event(), UserSetting()
+        )
+
+        assert outcome == "page_mismatch"
+        # 只有点击基质，没有动作按钮点击
+        assert len(engine._window_actions.click_calls) == 1
+
+    def test_stop_event_aborts(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        engine = build_engine(mock_scanner_context, mock_user_setting_manager, mock_profile)
+        stop_event = threading.Event()
+        stop_event.set()
+        record = make_record(1, 0, 0, (4, 4, 2), "wpn_A")
+
+        outcome = engine._visit_cleanup_records([record], stop_event, UserSetting())
+
+        assert outcome == "aborted"
+        assert engine._window_actions.click_calls == []
+
+
+# ── Draggable 导航 ──
+
+
+class TestDraggableNavigation:
+    def build_draggable(self, mock_scanner_context, mock_user_setting_manager, mock_profile):
+        engine = DraggableScannerEngine(
+            ctx=mock_scanner_context,
+            image_source=MockImageSource(),
+            window_actions=MockWindowActions(),
+            user_setting_manager=mock_user_setting_manager,
+            profile=mock_profile,
+        )
+        engine._cleanup_active = True
+        return engine
+
+    def test_reset_to_first_page_drag_geometry(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        mock_profile.SCROLLBAR_TOP_CHECK_POS = Point(1453, 130)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        # 顶部亮点一直检测不到 → 走满 3 次拖动手势后按已回顶继续
+        engine._check_scrollbar_at_top = MagicMock(return_value=False)
+
+        result = engine._reset_to_first_page(threading.Event())
+
+        assert result is True
+        assert len(engine._window_actions.drag_calls) == 3
+        # 拖动距离恒定 16px：起点 top+16 → 终点 top
+        start_x, start_y, end_x, end_y, *_ = engine._window_actions.drag_calls[0]
+        assert (start_x, start_y) == (1453, 146)
+        assert (end_x, end_y) == (1453, 130)
+
+    def test_reset_to_first_page_skips_drag_when_already_at_top(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        mock_profile.SCROLLBAR_TOP_CHECK_POS = Point(1453, 130)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._check_scrollbar_at_top = MagicMock(return_value=True)
+
+        assert engine._reset_to_first_page(threading.Event()) is True
+        assert engine._window_actions.drag_calls == []
+
+    def test_advance_to_page_flips_difference(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        mock_profile.essence_icon_y_list = [196, 351]
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._progressive_drag = MagicMock(return_value=(820, False))
+        engine._align_grid_rows_after_drag = MagicMock()
+        engine._check_scrollbar_at_bottom = MagicMock(return_value=False)
+
+        setting = UserSetting()
+        setting.fix_grid_row_offset_after_page_flip = True
+
+        result = engine._advance_to_page(1, 3, threading.Event(), setting)
+
+        assert result is True
+        assert engine._progressive_drag.call_count == 2
+        assert engine._align_grid_rows_after_drag.call_count == 2
+
+    def test_advance_to_page_stops_at_bottom(
+        self, mock_scanner_context, mock_user_setting_manager, mock_profile
+    ):
+        mock_profile.DRAG_START_POS = Point(750, 870)
+        mock_profile.DRAG_END_POS = Point(750, 50)
+        mock_profile.SCROLLBAR_CHECK_POS = Point(1453, 950)
+        engine = self.build_draggable(
+            mock_scanner_context, mock_user_setting_manager, mock_profile
+        )
+        engine._progressive_drag = MagicMock(return_value=(600, True))
+        engine._align_grid_rows_after_drag = MagicMock()
+
+        result = engine._advance_to_page(1, 4, threading.Event(), UserSetting())
+
+        assert result is True
+        # 检测到到底后不再翻页、不再对齐
+        assert engine._progressive_drag.call_count == 1
+        assert engine._align_grid_rows_after_drag.call_count == 0
+
+
+# ── claimer 路径标注 ──
+
+
+def _make_stat(stat_id: str, stat_type: StatType) -> EssenceStatV2:
+    return EssenceStatV2(stat_id=stat_id, name=stat_id, type=stat_type)
+
+
+_STAT_TABLE = {
+    "A": _make_stat("A", StatType.ATTRIBUTE),
+    "B": _make_stat("B", StatType.SECONDARY),
+    "C": _make_stat("C", StatType.SKILL),
+}
+
+
+def _mock_static_data() -> MagicMock:
+    mock_data = MagicMock()
+    mock_data.get_stat.side_effect = lambda sid: _STAT_TABLE.get(sid)
+    mock_data.find_weapons_by_stats.return_value = ["wpn_001"]
+    mock_data.get_weapon.return_value = None
+    mock_data.get_weapon_type.return_value = None
+    return mock_data
+
+
+def _profile_entry(levels: tuple[int, int, int]) -> TreasureMatrixEntry:
+    return TreasureMatrixEntry(
+        weapon_id="wpn_001",
+        weapon_name="测试武器",
+        affix1_level=levels[0],
+        affix2_level=levels[1],
+        affix3_level=levels[2],
+    )
+
+
+class TestClaimKindTagging:
+    def test_first_claim_is_new_slot(self):
+        setting = UserSetting()
+        setting.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        setting.same_type_treasure_limit = 1
+        setting.same_type_keep_best = False
+
+        context = ClaimContext([], setting)
+        static_data = _mock_static_data()
+        data = make_data([6, 6, 3])
+        classification = classify_essence(data, setting, static_data)
+
+        result = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+
+        assert result.claim_kind == ClaimKind.NEW_SLOT
+        assert result.owner_key == "wpn_001"
+
+    def test_existing_profile_entry_is_skip_existing(self):
+        setting = UserSetting()
+        setting.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        setting.same_type_treasure_limit = 1
+
+        context = ClaimContext([_profile_entry((6, 6, 3))], setting)
+        static_data = _mock_static_data()
+        data = make_data([6, 6, 3])
+        classification = classify_essence(data, setting, static_data)
+
+        result = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+
+        assert result.claim_kind == ClaimKind.SKIP_EXISTING
+        assert result.owner_key == "wpn_001"
+
+    def test_upgrade_reports_released_levels(self):
+        setting = UserSetting()
+        setting.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        setting.same_type_treasure_limit = 1
+
+        context = ClaimContext([_profile_entry((4, 4, 2))], setting)
+        static_data = _mock_static_data()
+        data = make_data([6, 5, 3])
+        classification = classify_essence(data, setting, static_data)
+
+        result = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+
+        assert result.claim_kind == ClaimKind.UPGRADE
+        assert result.released_levels == (4, 4, 2)
+        assert result.owner_key == "wpn_001"
+
+    def test_identical_level_within_limit_is_count_only(self):
+        setting = UserSetting()
+        setting.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        setting.same_type_treasure_limit = 2
+
+        context = ClaimContext([_profile_entry((6, 6, 3))], setting)
+        static_data = _mock_static_data()
+        data = make_data([6, 6, 3])
+        classification = classify_essence(data, setting, static_data)
+
+        # 第一枚：存量跳过（消耗相等跳过名额）
+        first = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+        assert first.claim_kind == ClaimKind.SKIP_EXISTING
+
+        # 第二枚：组内无空槽，仅计数占名额
+        second = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+        assert second.claim_kind == ClaimKind.COUNT_ONLY
+        assert second.owner_key == "wpn_001"
+
+    def test_limit_reject_is_none(self):
+        setting = UserSetting()
+        setting.same_type_group_mode = SameTypeGroupMode.BY_WEAPON
+        setting.same_type_treasure_limit = 1
+        setting.same_type_keep_best = False
+
+        context = ClaimContext([], setting)
+        static_data = _mock_static_data()
+        data = make_data([6, 6, 3])
+        classification = classify_essence(data, setting, static_data)
+
+        context.claim(classification, data, setting, static_game_data=static_data)
+        second = context.claim(
+            classification, data, setting, static_game_data=static_data
+        )
+
+        assert second.claim_kind == ClaimKind.NONE
+        assert second.owner_key is None


### PR DESCRIPTION
Closes #200 
单次扫描中，同一武器先扫到低等级、后扫到高等级的基质时两者都会被锁定，程序无法回溯弃用旧基质，产生冗余。
由于「宝藏基质」页面只记录每把武器的最优等级，无法还原名额与各级数量，清理在**扫描结束的同一会话内**执行，利用本轮完整认领记录判定冗余。

### 实现

- **记录**：扫描期（仅开关开启时）将每枚判定为宝藏的基质记入账本：位置（页/行/列逻辑索引，分辨率无关）、语义序等级、指纹、最终归属武器。
- **认领路径标注**：`ClaimResult` 新增 `claim_kind`（NEW_SLOT / UPGRADE / SKIP_EXISTING / COUNT_ONLY / VIRTUAL_SLOT / NONE），由 `claimer.py` 各返回路径显式标注；升级携带 `released_levels`。
- **名额账本**：镜像 ClaimContext 的名额状态机——升级释放旧持有者；级联把释放记录转移最终归属（孪生武器 / 非降级场景正确）。
- **清理导航**：扫描结束后（触发模式：仅在扫描到尾页时 / 所有情况含手动停止）→ 滚动条顶端 16px 上拖 + 顶部亮点检测回第一页（检测点与缩放律同 `SCROLLBAR_CHECK_POS` 对称，16px 不随分辨率缩放）→ 复用扫描的正向翻页机件逐页回访 → 每格重识别 + 指纹比对，不匹配跳过 + 警告，**整页全不匹配即放弃整个清理** → 按「对于冗余基质」操作规则执行。
- **动作**：`decide_actions` 新增 `target_action` 覆盖参数；清理动作复用现有条件语义（已处于目标状态则不操作）。
- **生命周期**：手动停止触发的清理会清除停止事件继续运行，可再次按停止取消；`ScannerService` 在线程真正退出时复位停止状态，避免 `is_running` 永久卡真。
- **设置**：`UserSetting` v8→v9，新增 `redundant_cleanup_enabled`（默认关，零记录零开销）、`redundant_cleanup_trigger`、`redundant_action`（默认「把它标记为弃用」）；设置页「基质操作规则」面板新增第三组 radio「对于冗余基质」及清理开关 / 时机。
- **布局**：`ResolutionProfile` 新增 `SCROLLBAR_TOP_CHECK_POS`（1080p + 动态缩放）。

### 已知限制

- 「按基质划分」（by_stat）分组暂不支持清理（跳过并日志提示）；
-  虚拟槽与武器归属的语义映射留待后续版本。

### 涉及文件

| 文件 | 改动 |
|---|---|
| `schemas/user_setting.py` | 冗余清理三字段 + v9 迁移 |
| `core/scanner/models.py` | `ClaimKind` 枚举 + `ClaimResult` 扩展字段 |
| `core/scanner/claimer.py` | 全认领路径 `claim_kind` 标注 |
| `core/scanner/engine.py` | 记录钩子、名额账本、清理导航与回访（`_CleanupRecord` 等） |
| `core/scanner/action_logic.py` | `decide_actions` 支持 `target_action` 覆盖 |
| `core/layout/base.py` / `res_1080p.py` / `dynamic.py` | 新增 `SCROLLBAR_TOP_CHECK_POS` |
| `services/scanner_service.py` | 线程退出时复位停止状态 |
| `frontend/src/pages/settings.vue` | 冗余清理开关 / 时机 / 第三组 radio，配置版本号同步为 9 |
| `tests/test_user_setting_manager.py` | v8→v9 迁移与 schema stability 测试 |
| `tests/unit/core/scanner/test_cleanup.py` | 新增 26 例：记录 / 账本 / 级联 / 判定 / 回访 / 导航 / 触发模式 |
| `tests/unit/core/scanner/test_action_logic.py` | `target_action` 覆盖测试 |

## Sourcery 摘要

添加实验性的冗余精华清理功能，记录扫描所有权，并在扫描后对已被取代的精华应用可配置的操作。

新功能：
- 添加实验性的扫描后模式，用于识别并清理分配给同一武器的冗余锁定精华。
- 在设置界面中提供冗余清理启用状态、触发时机和目标操作设置。

错误修复：
- 工作线程退出时重置扫描器停止状态，避免中断扫描和后续运行导致服务卡在运行状态。

增强功能：
- 跟踪声明路径和已释放等级，以保留每次扫描的所有权，并正确识别冗余精华，包括升级和级联场景。
- 复用扫描导航和指纹验证，以安全地重新访问并处理冗余精华；当整个页面都无法匹配时中止操作。
- 允许针对清理专用操作覆盖操作决策，并添加滚动到顶部的布局位置以支持返回导航。
- 将用户设置从版本 8 迁移到版本 9，并默认禁用冗余清理。

测试：
- 添加对冗余声明记录、升级级联、清理触发器、页面导航、指纹验证、清理操作、声明路径标记和设置迁移的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增实验性扫描后清理功能，用于处理冗余武器精华，并支持可配置的操作和安全的基于会话的跟踪。

新功能：
- 新增实验性扫描后模式，用于识别分配给同一武器的冗余宝藏精华，并应用可配置的清理操作。
- 在扫描器设置页面中提供冗余清理启用状态、触发时机和目标操作设置。

错误修复：
- 工作线程退出时重置扫描器停止状态，避免中断扫描后服务永久被标记为运行中。

增强功能：
- 在每次扫描期间跟踪领取归属、升级释放和级联重新分配，以准确确定冗余精华。
- 通过导航和指纹验证安全地重新访问已扫描页面；当页面内容无法匹配时中止清理。
- 允许覆盖仅适用于清理的操作，并支持导航返回第一页。

测试：
- 增加对冗余领取记账、升级级联、清理触发、导航、指纹验证、清理操作、领取标记和设置迁移的测试覆盖。

杂项：
- 将用户设置从版本 8 迁移到版本 9，并默认禁用冗余清理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增实验性扫描后清理功能，用于处理冗余武器精华，并通过基于会话的所有权跟踪和可配置操作进行管理。

新功能：
- 新增实验性扫描后模式，用于识别同一武器中被后续或更优精华替代的冗余精华，并应用可配置的清理操作。
- 在扫描器设置界面中公开冗余清理启用状态、触发时机和目标操作设置。

错误修复：
- 工作线程退出时重置扫描器线程和停止状态，避免中断扫描后服务被永久标记为运行中。

增强功能：
- 在每次扫描期间跟踪声明路径、所有权、升级和级联释放，以便根据完整的会话记录确定冗余精华。
- 通过共享导航和指纹验证安全地重新访问已扫描页面；如果无法匹配页面内容，则中止清理。
- 允许覆盖专用于清理的操作，并支持导航返回第一页。

测试：
- 增加对冗余声明统计、升级级联、清理触发条件、导航、指纹验证、清理操作、声明标记和设置迁移的测试覆盖。

维护工作：
- 将用户设置从版本 8 迁移到版本 9，并默认禁用冗余清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add experimental post-scan cleanup for redundant weapon essences with session-based ownership tracking and configurable actions.

New Features:
- Add an experimental post-scan mode that identifies redundant essences replaced by later or better essences for the same weapon and applies a configurable cleanup action.
- Expose redundant-cleanup enablement, trigger timing, and target action settings in the scanner settings UI.

Bug Fixes:
- Reset scanner thread and stopping state when the worker exits so interrupted scans do not leave the service permanently marked as running.

Enhancements:
- Track claim paths, ownership, upgrades, and cascaded releases during each scan to determine redundant essences from complete session records.
- Safely revisit scanned pages using shared navigation and fingerprint validation, aborting cleanup when page contents cannot be matched.
- Allow cleanup-specific action overrides and support navigation back to the first page.

Tests:
- Add coverage for redundant-claim accounting, upgrade cascades, cleanup triggers, navigation, fingerprint validation, cleanup actions, claim tagging, and settings migration.

Chores:
- Migrate user settings from version 8 to 9 with redundant cleanup disabled by default.

</details>

</details>

</details>