### PR TITLE
feat(planner): 基质规划页新增刷取地点筛选并持久化到 profiles.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ exports/
 
 # local app settings
 config.json
+config.backup.*.json
 .env
 profiles.json
 version.json

--- a/frontend/src/composables/__tests__/useProfiles.test.ts
+++ b/frontend/src/composables/__tests__/useProfiles.test.ts
@@ -292,6 +292,34 @@ describe('useProfiles', () => {
     expect(activeProfile.value.matrix_badge_display_mode).toBe('medium')
   })
 
+  it('updateMatrixPlannerFarmingLocations 发送地点筛选并更新本地账号快照', async () => {
+    const locations = {
+      world_energy_point_group01: true,
+      world_energy_point_group02: false,
+    }
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        version: 1,
+        name: 'default',
+        treasure_matrix: [],
+        matrix_planner_farming_locations: locations,
+      }),
+    )
+    const { updateMatrixPlannerFarmingLocations, activeProfile } = useProfiles()
+
+    await updateMatrixPlannerFarmingLocations(locations)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/profiles/matrix_planner_farming_locations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ locations }),
+      }),
+    )
+    expect(activeProfile.value.matrix_planner_farming_locations).toEqual(locations)
+  })
+
   it('写操作接口返回 ProfileData 时直接更新本地快照，不重复拉取', async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({

--- a/frontend/src/composables/useProfiles.ts
+++ b/frontend/src/composables/useProfiles.ts
@@ -31,6 +31,8 @@ export interface ProfileData {
   weapon_priorities?: Record<string, number>
   switch_display_mode?: 'chip' | 'dot' | 'off'
   matrix_badge_display_mode?: 'small' | 'medium' | 'off'
+  /** 基质规划页刷取地点筛选：battleId -> 是否勾选；缺失的键默认视为勾选 */
+  matrix_planner_farming_locations?: Record<string, boolean>
 }
 
 export interface ProfileCollection {
@@ -377,6 +379,24 @@ export function useProfiles() {
     }
   }
 
+  async function updateMatrixPlannerFarmingLocations(locations: Record<string, boolean>) {
+    try {
+      const res = await fetch('/api/profiles/matrix_planner_farming_locations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ locations }),
+      })
+      applyActiveProfile(
+        await parseJsonResponse<ProfileData>(
+          res,
+          'Failed to update matrix planner farming locations',
+        ),
+      )
+    } catch (error) {
+      _handleError('更新基质规划刷取地点筛选失败', error)
+    }
+  }
+
   async function updateWeaponPriority(weaponId: string, priority: number) {
     try {
       const res = await fetch('/api/profiles/weapon_priority', {
@@ -413,6 +433,7 @@ export function useProfiles() {
     updateWeaponOverviewFilters,
     updateSwitchDisplayMode,
     updateMatrixBadgeDisplayMode,
+    updateMatrixPlannerFarmingLocations,
     updateWeaponPriority,
   }
 }

--- a/frontend/src/pages/__tests__/matrixPlannerFarmingLocations.test.ts
+++ b/frontend/src/pages/__tests__/matrixPlannerFarmingLocations.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, watch } from 'vue'
+
+/**
+ * 基质规划页「刷取地点筛选」：配置回填与用户落盘的区分。
+ *
+ * 页面把筛选状态拆成两个 watcher（回填 / 落盘），二者都会改动
+ * selectedFarmingLocations，靠「当前勾选是否等于已保存配置推出的勾选」来区分
+ * 用户意图。这个判据不显眼，且回填的赋值会让落盘 watcher 在之后的 flush 中
+ * 才执行，容易在后续改动中被破坏成「回填即回写」（把已保存配置写坏、账号切换
+ * 时串号），因此用本测试固定住行为。
+ *
+ * 项目未引入 @vue/test-utils 与 DOM 环境，这里用与 matrix-planner.vue 中两个
+ * watcher 逐行同构的 harness 覆盖该逻辑；改动组件里这两段时请同步更新本文件。
+ */
+function buildHarness(initialOptions?: { battleId: string; battleName: string }[]) {
+  const save = vi.fn()
+  const defaultOptions = [
+    { battleId: 'opt1', battleName: 'A' },
+    { battleId: 'opt2', battleName: 'B' },
+    { battleId: 'opt3', battleName: 'C' },
+  ]
+  const alluviumLocationOptions = ref(initialOptions ?? defaultOptions)
+  const savedFarmingLocations = ref<Record<string, boolean>>({})
+  const selectedFarmingLocations = ref<string[]>([])
+  const farmingLocationFilterReady = ref(false)
+
+  watch(
+    [alluviumLocationOptions, savedFarmingLocations],
+    ([options, saved]) => {
+      if (options.length === 0) return
+      const next = options
+        .filter((option) => saved[option.battleId] ?? true)
+        .map((option) => option.battleId)
+      const current = selectedFarmingLocations.value.toSorted().join(',')
+      if (next.toSorted().join(',') !== current) {
+        selectedFarmingLocations.value = next
+      }
+      farmingLocationFilterReady.value = true
+    },
+    { immediate: true },
+  )
+
+  watch(
+    selectedFarmingLocations,
+    async (newValue, oldValue) => {
+      if (!farmingLocationFilterReady.value) return
+      const oldSorted = oldValue.toSorted().join(',')
+      const newSorted = newValue.toSorted().join(',')
+      if (oldSorted === newSorted) return
+
+      const synced = alluviumLocationOptions.value
+        .filter((option) => savedFarmingLocations.value[option.battleId] ?? true)
+        .map((option) => option.battleId)
+      if (synced.toSorted().join(',') === newSorted) return
+
+      const locations: Record<string, boolean> = {}
+      for (const option of alluviumLocationOptions.value) {
+        locations[option.battleId] = newValue.includes(option.battleId)
+      }
+      save(locations)
+    },
+    { deep: true },
+  )
+
+  const noFarmingLocationSelected = computed(
+    () => farmingLocationFilterReady.value && selectedFarmingLocations.value.length === 0,
+  )
+
+  return {
+    save,
+    alluviumLocationOptions,
+    savedFarmingLocations,
+    selectedFarmingLocations,
+    farmingLocationFilterReady,
+    noFarmingLocationSelected,
+    /** 模拟用户点击 chip */
+    clickChip(newSelection: string[]) {
+      selectedFarmingLocations.value = [...newSelection]
+    },
+  }
+}
+
+describe('刷取地点筛选：回填与落盘的区分', () => {
+  it('首次挂载默认全勾选，不落盘', async () => {
+    const h = buildHarness()
+    await nextTick()
+
+    expect(h.selectedFarmingLocations.value).toEqual(['opt1', 'opt2', 'opt3'])
+    expect(h.save).not.toHaveBeenCalled()
+  })
+
+  it('刷新页面：配置异步到达后回填，不落盘', async () => {
+    const h = buildHarness()
+    await nextTick()
+
+    // fetchProfiles 返回：opt1 未勾选
+    h.savedFarmingLocations.value = { opt1: false, opt2: true, opt3: true }
+    await nextTick()
+
+    expect(h.selectedFarmingLocations.value).toEqual(['opt2', 'opt3'])
+    expect(h.save).not.toHaveBeenCalled()
+  })
+
+  it('配置再次变化（新增取消勾选）仍不落盘', async () => {
+    const h = buildHarness()
+    await nextTick()
+    h.savedFarmingLocations.value = { opt1: false, opt2: true, opt3: true }
+    await nextTick()
+
+    h.savedFarmingLocations.value = { opt1: false, opt2: true, opt3: false }
+    await nextTick()
+
+    expect(h.selectedFarmingLocations.value).toEqual(['opt2'])
+    expect(h.save).not.toHaveBeenCalled()
+  })
+
+  it('切换账号：用新账号配置回填，不落盘', async () => {
+    const h = buildHarness()
+    await nextTick()
+    h.savedFarmingLocations.value = { opt1: false, opt2: true, opt3: true }
+    await nextTick()
+
+    // 切到另一个账号：全勾选
+    h.savedFarmingLocations.value = { opt1: true, opt2: true, opt3: true }
+    await nextTick()
+
+    expect(h.selectedFarmingLocations.value).toEqual(['opt1', 'opt2', 'opt3'])
+    expect(h.save).not.toHaveBeenCalled()
+  })
+
+  it('用户取消勾选后落盘，且发送全量 map', async () => {
+    const h = buildHarness()
+    await nextTick()
+
+    h.clickChip(['opt2', 'opt3'])
+    await nextTick()
+
+    expect(h.save).toHaveBeenCalledTimes(1)
+    expect(h.save).toHaveBeenCalledWith({ opt1: false, opt2: true, opt3: true })
+  })
+
+  it('回填之后用户改动依然落盘（基准已更新，不误判）', async () => {
+    const h = buildHarness()
+    await nextTick()
+    h.savedFarmingLocations.value = { opt1: false, opt2: true, opt3: true }
+    await nextTick()
+
+    h.clickChip(['opt2'])
+    await nextTick()
+
+    expect(h.save).toHaveBeenCalledTimes(1)
+    expect(h.save).toHaveBeenCalledWith({ opt1: false, opt2: true, opt3: false })
+  })
+
+  it('改回与已保存配置一致时不落盘（无实际变更）', async () => {
+    const h = buildHarness()
+    await nextTick()
+    h.clickChip(['opt2', 'opt3'])
+    await nextTick()
+    h.save.mockClear()
+
+    // 再改回初始的全勾选，与已保存配置一致 —— 无需回写
+    h.clickChip(['opt1', 'opt2', 'opt3'])
+    await nextTick()
+
+    expect(h.save).not.toHaveBeenCalled()
+  })
+
+  it('全部取消勾选：落盘全 false 并给出提示', async () => {
+    const h = buildHarness()
+    await nextTick()
+
+    h.clickChip([])
+    await nextTick()
+
+    expect(h.noFarmingLocationSelected.value).toBe(true)
+    expect(h.save).toHaveBeenCalledWith({ opt1: false, opt2: false, opt3: false })
+  })
+
+  it('静态数据未就绪时不回填、不落盘', async () => {
+    const h = buildHarness([])
+    await nextTick()
+
+    expect(h.farmingLocationFilterReady.value).toBe(false)
+    expect(h.save).not.toHaveBeenCalled()
+    expect(h.noFarmingLocationSelected.value).toBe(false)
+
+    // 静态数据到达后正常回填
+    h.alluviumLocationOptions.value = [
+      { battleId: 'opt1', battleName: 'A' },
+      { battleId: 'opt2', battleName: 'B' },
+    ]
+    await nextTick()
+
+    expect(h.selectedFarmingLocations.value).toEqual(['opt1', 'opt2'])
+    expect(h.farmingLocationFilterReady.value).toBe(true)
+    expect(h.save).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/matrix-planner.vue
+++ b/frontend/src/pages/matrix-planner.vue
@@ -100,7 +100,10 @@
                   </v-card>
                 </div>
                 <v-alert v-else border="start" type="info" variant="tonal">
-                  开启「不使用预刻券」模式后，将显示所有刷取地点。
+                  <template v-if="noFarmingLocationSelected">
+                    未勾选任何刷取地点，请在右侧「需求设定」中至少勾选一个。
+                  </template>
+                  <template v-else> 开启「不使用预刻券」模式后，将显示所有刷取地点。 </template>
                 </v-alert>
               </template>
               <!-- 使用预刻券模式：左右布局 -->
@@ -250,7 +253,12 @@
                   </v-card>
                 </div>
                 <v-alert v-else border="start" type="info" variant="tonal">
-                  请在右侧添加需求的基质属性，系统会自动计算最优刷取方案。
+                  <template v-if="noFarmingLocationSelected">
+                    未勾选任何刷取地点，请在右侧「需求设定」中至少勾选一个。
+                  </template>
+                  <template v-else>
+                    请在右侧添加需求的基质属性，系统会自动计算最优刷取方案。
+                  </template>
                 </v-alert>
               </template>
             </v-expansion-panel-text>
@@ -294,6 +302,33 @@
                   你可以从武器预设中选择，也可以自定义属性组合。
                 </template>
               </p>
+
+              <!-- 刷取地点筛选 -->
+              <div class="mb-4">
+                <div class="d-flex align-center mb-1">
+                  <span class="text-body-2 text-medium-emphasis">刷取地点：</span>
+                  <v-tooltip text="仅显示勾选的能量淤积点，取消勾选的地点不会出现在左侧方案中">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" class="ml-1" color="medium-emphasis" size="small"
+                        >mdi-information-outline</v-icon
+                      >
+                    </template>
+                  </v-tooltip>
+                </div>
+                <v-chip-group v-model="selectedFarmingLocations" column multiple>
+                  <v-chip
+                    v-for="location in alluviumLocationOptions"
+                    :key="location.battleId"
+                    color="primary"
+                    filter
+                    size="small"
+                    :value="location.battleId"
+                    variant="outlined"
+                  >
+                    {{ getDisplayName(location.battleName) }}
+                  </v-chip>
+                </v-chip-group>
+              </div>
 
               <template v-if="!noPrecraftMode">
                 <!-- Selected requirements -->
@@ -630,7 +665,7 @@ import {
 
 const route = useRoute()
 const { weaponTypes, weaponsMap, essencesMap, matrixIcons } = useStaticData()
-const { treasureMatrix } = useProfiles()
+const { treasureMatrix, activeProfile, updateMatrixPlannerFarmingLocations } = useProfiles()
 const { selectedRarities } = useRarityFilters()
 const { customStats, customMatrixEntries, fetchCustomStats } = useCustomStats()
 
@@ -657,7 +692,7 @@ const {
   moveStatDown,
   getEssenceStatDescription,
   getStatDisplayName,
-  bestChoices,
+  allChoices,
   clearAllStats,
 } = useMatrixPlanner(obtainedWeaponIds)
 
@@ -738,6 +773,76 @@ const noPrecraftMode = ref(false)
 /** 不使用预刻券模式下选中的武器ID，用于置顶包含该武器的地点 */
 const selectedWeaponForLocation = ref<string | null>(null)
 
+// --- 刷取地点筛选 ---
+
+/** 所有可选的刷取地点（能量淤积点） */
+const alluviumLocationOptions = computed(() =>
+  Object.values(energyAlluviums.value).map((alluvium) => ({
+    battleId: alluvium.battleId,
+    battleName: alluvium.battleName,
+  })),
+)
+
+/** 已落盘的刷取地点筛选配置（battleId -> 是否勾选） */
+const savedFarmingLocations = computed(
+  () => activeProfile.value.matrix_planner_farming_locations ?? {},
+)
+
+/** 当前勾选的刷取地点 battleId 列表，默认全部勾选 */
+const selectedFarmingLocations = ref<string[]>([])
+
+/** 刷取地点数据是否已就绪；就绪前不做过滤，避免静态数据到达前误清空方案 */
+const farmingLocationFilterReady = ref(false)
+
+/** 是否因未勾选任何刷取地点而导致方案列表为空 */
+const noFarmingLocationSelected = computed(
+  () => farmingLocationFilterReady.value && selectedFarmingLocations.value.length === 0,
+)
+
+// 静态数据或已保存配置变化时同步勾选状态（配置中缺失的键默认视为勾选）
+watch(
+  [alluviumLocationOptions, savedFarmingLocations],
+  ([options, saved]) => {
+    if (options.length === 0) return
+    const next = options
+      .filter((option) => saved[option.battleId] ?? true)
+      .map((option) => option.battleId)
+    const current = selectedFarmingLocations.value.toSorted().join(',')
+    if (next.toSorted().join(',') !== current) {
+      selectedFarmingLocations.value = next
+    }
+    farmingLocationFilterReady.value = true
+  },
+  { immediate: true },
+)
+
+// 勾选状态变化时落盘保存；由加载同步引起的变化不回写，避免冗余写盘
+watch(
+  selectedFarmingLocations,
+  async (newValue, oldValue) => {
+    if (!farmingLocationFilterReady.value) return
+    const oldSorted = oldValue.toSorted().join(',')
+    const newSorted = newValue.toSorted().join(',')
+    if (oldSorted === newSorted) return
+
+    const synced = alluviumLocationOptions.value
+      .filter((option) => savedFarmingLocations.value[option.battleId] ?? true)
+      .map((option) => option.battleId)
+    if (synced.toSorted().join(',') === newSorted) return
+
+    const locations: Record<string, boolean> = {}
+    for (const option of alluviumLocationOptions.value) {
+      locations[option.battleId] = newValue.includes(option.battleId)
+    }
+    try {
+      await updateMatrixPlannerFarmingLocations(locations)
+    } catch {
+      // 错误已由 useProfiles 的 lastError 处理
+    }
+  },
+  { deep: true },
+)
+
 // 需求武器集合被按钮状态、排序和方案统计共用，集中计算可保持口径一致。
 const selectedRequiredWeaponIds = computed(
   () =>
@@ -810,6 +915,12 @@ const allLocationChoices = computed<LocationChoice[]>(() => {
 const displayedLocationChoices = computed<LocationChoice[]>(() => {
   let locations = [...allLocationChoices.value]
 
+  // 按勾选的刷取地点过滤
+  if (farmingLocationFilterReady.value) {
+    const enabled = new Set(selectedFarmingLocations.value)
+    locations = locations.filter((choice) => enabled.has(choice.battleId))
+  }
+
   // 如果选中了武器，将包含该武器的地点置顶
   if (selectedWeaponForLocation.value) {
     locations = locations.toSorted((a, b) => {
@@ -832,9 +943,20 @@ const displayedLocationChoices = computed<LocationChoice[]>(() => {
 
 /**
  * 使用预刻券模式下显示的方案列表
+ *
+ * 先在全部有效方案上按勾选地点过滤，再取前 5 个，避免先截断后过滤
+ * 导致勾选地点中的有效方案被挤出列表。
  */
 const displayedBattleChoices = computed<BattleChoice[]>(() => {
-  return bestChoices.value
+  let choices = allChoices.value
+
+  // 按勾选的刷取地点过滤
+  if (farmingLocationFilterReady.value) {
+    const enabled = new Set(selectedFarmingLocations.value)
+    choices = choices.filter((choice) => enabled.has(choice.battleId))
+  }
+
+  return choices.slice(0, 5)
 })
 
 // 武器图标渲染时会逐个判断是否命中当前方案，预先汇总命中集合减少模板函数开销。

--- a/frontend/src/pages/matrix-planner.vue
+++ b/frontend/src/pages/matrix-planner.vue
@@ -825,6 +825,9 @@ watch(
     const newSorted = newValue.toSorted().join(',')
     if (oldSorted === newSorted) return
 
+    // 当前勾选状态与「已保存配置 + 剩余地点默认勾选」一致时说明这是回填而非用户改动。
+    // saved 的键恒为 alluviumLocationOptions 的子集（battleId 来自固定的 EnergyAlluviums.json），
+    // 因此这个比较口径与回填 watcher 一致，不会漏掉用户真实的取消勾选。
     const synced = alluviumLocationOptions.value
       .filter((option) => savedFarmingLocations.value[option.battleId] ?? true)
       .map((option) => option.battleId)

--- a/src/endfield_essence_recognizer/api/routes/profiles.py
+++ b/src/endfield_essence_recognizer/api/routes/profiles.py
@@ -439,6 +439,21 @@ async def update_weapon_overview_filters(
     return manager.update_weapon_overview_filters(request.filters)
 
 
+class UpdateMatrixPlannerFarmingLocationsRequest(BaseModel):
+    """更新基质规划刷取地点筛选的请求体。"""
+
+    locations: dict[str, bool] = Field(default_factory=dict)
+
+
+@router.post("/matrix_planner_farming_locations")
+async def update_matrix_planner_farming_locations(
+    request: UpdateMatrixPlannerFarmingLocationsRequest,
+    manager: ProfileManager = Depends(get_profile_manager),
+) -> ProfileData:
+    """更新当前激活账号的基质规划刷取地点筛选配置。"""
+    return manager.update_matrix_planner_farming_locations(request.locations)
+
+
 VALID_SWITCH_MODES: Final = {"chip", "dot", "off"}
 
 

--- a/src/endfield_essence_recognizer/schemas/profile.py
+++ b/src/endfield_essence_recognizer/schemas/profile.py
@@ -85,6 +85,10 @@ class ProfileData(BaseModel):
     matrix_badge_display_mode: Literal["small", "medium", "off"] = "small"
     """武器总览基质图标显示模式：'small'=小号(默认), 'medium'=中号(2倍), 'off'=关闭。"""
 
+    matrix_planner_farming_locations: dict[str, bool] = Field(default_factory=dict)
+    """基质规划页刷取地点筛选配置。键为淤积点 battleId，值为是否勾选；
+    缺失的键默认视为勾选（即默认全部勾选）。"""
+
 
 class ProfileCollection(BaseModel):
     """所有账号的集合。"""

--- a/src/endfield_essence_recognizer/services/profile_manager.py
+++ b/src/endfield_essence_recognizer/services/profile_manager.py
@@ -740,10 +740,11 @@ class ProfileManager:
             return profile.model_copy(deep=True)
 
     def clear_profile_data(self, name: str | None = None) -> ProfileData:
-        """清空指定账号的宝藏基质数据（保留账号本身、名称、版本与总览过滤器）。
+        """清空指定账号的宝藏基质数据（保留账号本身、名称、版本与展示偏好）。
 
         清空内容为 treasure_matrix 与 weapon_priorities，用于「数据有误、
-        全量重新扫描」的场景；不删除账号，也不重置武器总览过滤器等展示偏好。
+        全量重新扫描」的场景；不删除账号，也不重置武器总览过滤器、
+        刷取地点筛选等展示偏好。
 
         Args:
             name: 要清空的账号名称；None 表示清空当前激活账号。

--- a/src/endfield_essence_recognizer/services/profile_manager.py
+++ b/src/endfield_essence_recognizer/services/profile_manager.py
@@ -801,6 +801,24 @@ class ProfileManager:
             self._commit_collection_unlocked(collection)
             return profile.model_copy(deep=True)
 
+    def update_matrix_planner_farming_locations(
+        self, locations: dict[str, bool]
+    ) -> ProfileData:
+        """更新激活账号的基质规划刷取地点筛选配置。
+
+        Args:
+            locations: 刷取地点筛选配置字典（battleId -> 是否勾选）。
+
+        Returns:
+            更新后的 ProfileData。
+        """
+        with self._lock:
+            collection = self._collection.model_copy(deep=True)
+            profile = collection.get_active()
+            profile.matrix_planner_farming_locations = locations
+            self._commit_collection_unlocked(collection)
+            return profile.model_copy(deep=True)
+
     def update_switch_display_mode(self, mode: str) -> ProfileData:
         """更新激活账号的"可切换"提示显示模式。
 

--- a/tests/integration/test_profiles_api.py
+++ b/tests/integration/test_profiles_api.py
@@ -73,3 +73,24 @@ def test_batch_farming_unknown_weapon_returns_error(client):
     results = response.json()
     assert results[0]["error"] == "Weapon not found"
     assert results[0]["recommendation"] is None
+
+
+def test_update_matrix_planner_farming_locations(client):
+    """刷取地点筛选通过 API 更新并返回完整账号数据。"""
+    locations = {
+        "world_energy_point_group01": True,
+        "world_energy_point_group02": False,
+    }
+    response = client.post(
+        "/api/profiles/matrix_planner_farming_locations",
+        json={"locations": locations},
+    )
+    assert response.status_code == 200
+    assert response.json()["matrix_planner_farming_locations"] == locations
+
+
+def test_update_matrix_planner_farming_locations_empty_body(client):
+    """空请求体默认为空筛选配置，不报错。"""
+    response = client.post("/api/profiles/matrix_planner_farming_locations", json={})
+    assert response.status_code == 200
+    assert response.json()["matrix_planner_farming_locations"] == {}

--- a/tests/unit/services/test_profile_manager.py
+++ b/tests/unit/services/test_profile_manager.py
@@ -619,15 +619,51 @@ def test_clear_profile_data_active(profile_manager: ProfileManager):
     profile_manager.update_weapon_overview_filters(
         {"3star": False, "4star": True, "5star": True, "6star": True, "custom": True}
     )
+    profile_manager.update_matrix_planner_farming_locations(
+        {"world_energy_point_group01": False, "world_energy_point_group02": True}
+    )
 
     cleared = profile_manager.clear_profile_data()
 
     assert cleared.treasure_matrix == []
     assert cleared.weapon_priorities == {}
-    # 展示偏好（过滤器）、名称与版本保留
+    # 展示偏好（过滤器、刷取地点筛选）、名称与版本保留
     assert cleared.weapon_overview_filters["3star"] is False
+    assert cleared.matrix_planner_farming_locations == {
+        "world_energy_point_group01": False,
+        "world_energy_point_group02": True,
+    }
     assert cleared.name == "default"
     assert cleared.version == 1
+
+
+def test_update_matrix_planner_farming_locations_persists(
+    profile_manager: ProfileManager, temp_profiles_file: Path
+):
+    """刷取地点筛选更新后立即落盘，重新加载后保持不变。"""
+    profile_manager.load()
+    locations = {
+        "world_energy_point_group01": True,
+        "world_energy_point_group02": False,
+    }
+
+    profile = profile_manager.update_matrix_planner_farming_locations(locations)
+
+    assert profile.matrix_planner_farming_locations == locations
+    data = json.loads(temp_profiles_file.read_text(encoding="utf-8"))
+    assert data["profiles"]["default"]["matrix_planner_farming_locations"] == locations
+
+    reloaded = ProfileManager(temp_profiles_file)
+    reloaded.load()
+    assert reloaded.get_active_profile().matrix_planner_farming_locations == locations
+
+
+def test_update_matrix_planner_farming_locations_defaults_empty(
+    profile_manager: ProfileManager,
+):
+    """未设置过刷取地点筛选时默认为空字典（前端视缺失键为全部勾选）。"""
+    profile_manager.load()
+    assert profile_manager.get_active_profile().matrix_planner_farming_locations == {}
 
 
 def test_clear_profile_data_named_keeps_active(profile_manager: ProfileManager):


### PR DESCRIPTION
Closes #208 
基质规划页此前会展示全部 11 个能量淤积点，用户无法排除不感兴趣的地点。
本 PR 在「基质规划页面-需求设定」中新增刷取地点筛选，默认全部勾选，选择随账号持久化。

## 改动
- 后端：ProfileData 新增 matrix_planner_farming_locations（dict[battleId, bool]，缺失键默认勾选，旧 profiles.json 无需迁移），新增更新接口与落盘逻辑
- 前端：useProfiles 增加字段与保存函数；基质规划页新增筛选 chip 组，变更自动保存；
- 不使用预刻券模式过滤地点列表，使用预刻券模式先过滤再取最优 5 个方案，全部取消勾选时给出提示
- 清空账号数据时保留筛选（与武器总览过滤器同为展示偏好）
- 测试：后端单元（落盘/重载/默认值/清空保留）与 API 集成测试，前端 useProfiles 保存函数测试

## images
<img width="158" height="89" alt="ebe9539a5774c0669d29d774f9d99a24" src="https://github.com/user-attachments/assets/764c3054-c15a-4e11-912b-329d27941051" />

<img width="158" height="89" alt="2cd744b2aadff4f35ec87e3422918ddf" src="https://github.com/user-attachments/assets/5b777ead-966c-4e1a-b3d2-c1eecaa93185" />

## Sourcery 摘要

为矩阵规划器添加持久化的刷取地点选择功能。

新功能：
- 为矩阵规划器添加可配置的刷取地点筛选器，默认选择所有地点，并按账号持久化保存更改。

增强功能：
- 根据所选地点筛选规划器结果，并在未选择任何地点时提供指导。
- 清除账号数据时保留矩阵规划器的地点偏好设置。

测试：
- 添加前端、API 集成和配置管理器测试覆盖，用于验证地点筛选器的更新、持久化、重新加载、默认设置和保留功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为矩阵规划器添加可配置且跨账户持久保存的刷取地点筛选器。

新功能：
- 为矩阵规划器添加持久化的刷取地点选择功能，默认启用所有地点。

增强功能：
- 根据所选刷取地点筛选规划器结果，并在未选择任何地点时提供指导。
- 清除账户数据时保留矩阵规划器的地点偏好设置。

测试：
- 添加前端、API 集成和个人资料管理器测试，覆盖地点偏好的更新、持久化、重新加载、默认设置和保留。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为矩阵规划器添加持久化的 farming-location 选择功能。

新功能：
- 为矩阵规划器添加可配置的 farming-location 筛选器，默认选择所有位置，并按账户持久化选择结果。

增强功能：
- 根据所选的 farming-location 筛选规划器结果，并在未选择任何位置时提供指导。
- 清除账户数据时保留矩阵规划器的 farming-location 偏好设置。

测试：
- 添加前端、API 集成和 profile-manager 测试覆盖，用于验证 farming-location 偏好的更新、持久化、重新加载、默认设置和保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add persistent farming-location selection to the matrix planner.

New Features:
- Add a configurable farming-location filter to the matrix planner, defaulting to all locations and persisting selections per account.

Enhancements:
- Filter planner results by selected farming locations and provide guidance when none are selected.
- Preserve matrix planner farming-location preferences when clearing account data.

Tests:
- Add frontend, API integration, and profile-manager coverage for updating, persisting, reloading, defaulting, and preserving farming-location preferences.

</details>

</details>

</details>